### PR TITLE
Navigation Base 로직 구현

### DIFF
--- a/core/navigation/build.gradle.kts
+++ b/core/navigation/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.twix.android.library)
     alias(libs.plugins.twix.android.compose)
+    alias(libs.plugins.twix.koin)
 }
 
 android {

--- a/core/navigation/src/main/java/com/twix/navigation/AppNavHost.kt
+++ b/core/navigation/src/main/java/com/twix/navigation/AppNavHost.kt
@@ -1,0 +1,60 @@
+package com.twix.navigation
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.rememberNavController
+import com.twix.navigation.base.NavGraphContributor
+import org.koin.compose.getKoin
+
+@Composable
+fun AppNavHost() {
+    val navController = rememberNavController()
+    val koin = getKoin()
+    val contributors = remember {
+        koin.getAll<NavGraphContributor>().sortedBy { it.priority }
+    }
+    val start = contributors
+        .firstOrNull { it.graphRoute == NavRoutes.LoginGraph }
+        ?.graphRoute
+        ?: error("해당 Graph를 찾을 수 없습니다.")
+    val duration = 300
+
+    NavHost(
+        navController = navController,
+        startDestination = start.route,
+        enterTransition = {
+            slideInHorizontally(
+                initialOffsetX = { fullWidth -> fullWidth },
+                animationSpec = tween(duration, easing = FastOutSlowInEasing)
+            )
+        },
+        exitTransition = {
+            slideOutHorizontally(
+                targetOffsetX = { fullWidth -> -fullWidth },
+                animationSpec = tween(duration, easing = FastOutSlowInEasing)
+            )
+        },
+        popEnterTransition = {
+            slideInHorizontally(
+                initialOffsetX = { fullWidth -> -fullWidth },
+                animationSpec = tween(duration, easing = FastOutSlowInEasing)
+            )
+        },
+        popExitTransition = {
+            slideOutHorizontally(
+                targetOffsetX = { fullWidth -> fullWidth },
+                animationSpec = tween(duration, easing = FastOutSlowInEasing)
+            )
+        },
+        modifier = Modifier.fillMaxSize()
+    ) {
+        contributors.forEach { with(it) { registerGraph(navController) } }
+    }
+}

--- a/core/navigation/src/main/java/com/twix/navigation/NavRoutes.kt
+++ b/core/navigation/src/main/java/com/twix/navigation/NavRoutes.kt
@@ -1,0 +1,20 @@
+package com.twix.navigation
+
+/**
+ * 앱 전반에서 사용하는 Navigation Route를 여기에서 정의합니다.
+ *
+ * · 문자열 route를 직접 사용하지 않고 타입 안정성을 위해 sealed class를 활용합니다.
+ * · navigation argument가 필요한 경우 createRoute()를 통해 route를 생성합니다.
+ * · Graph의 경우 _graph로 네이밍하고 Screen의 경우에는 Composable명에서 Screen을 제외한 앞부분을 활용합니다. ex) HomeScreen -> home
+ * */
+sealed class NavRoutes(val route: String) {
+    object LoginGraph: NavRoutes("login_graph")
+    object Login: NavRoutes("login")
+
+    object HomeGraph: NavRoutes("home_graph")
+    object Home: NavRoutes("home")
+
+    object HomeDetail: NavRoutes("home_detail/{id}") {
+        fun createRoute(id: String) = "home_detail/$id"
+    }
+}

--- a/core/navigation/src/main/java/com/twix/navigation/base/NavGraphContributor.kt
+++ b/core/navigation/src/main/java/com/twix/navigation/base/NavGraphContributor.kt
@@ -1,0 +1,17 @@
+package com.twix.navigation.base
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import com.twix.navigation.NavRoutes
+
+/**
+ * priority는 우선적으로 등록해야 하는 Graph에서 값을 낮춰 사용하면 됩니다.
+ * ex) SplashGraph는 앱 내에서 가장 먼저 실행되어야 하는 그래프이므로 priority를 낮춰주면 됩니다.
+ **/
+interface NavGraphContributor {
+    val graphRoute: NavRoutes
+    val startDestination: String
+    val priority: Int get() = 100
+
+    fun NavGraphBuilder.registerGraph(navController: NavHostController)
+}


### PR DESCRIPTION
## 이슈 번호
- close #20 

## 작업내용
* :feature:*에서 구현해야 할 NavGraphContributor를 정의했습니다.
* AppNavHost에서 일괄적으로 NavGraphContributor를 등록하도록 구현했습니다.
* 앱 전반의 Navigation Route를 관리할 NavRoutes를 정의했습니다.

## 리뷰어에게 추가로 요구하는 사항 (선택)
* 현재 NavRoutes에 추가해둔 route는 예시를 위해 임시로 추가한 값입니다.
* AppNavHost는 MainActivity에서 호출하여 네비게이션을 위임하는 것으로 구현할 예정입니다.
