### PR TITLE
코멘트 텍스트 필드 리뷰 반영 및 버그 수정

### DIFF
--- a/core/design-system/src/main/java/com/twix/designsystem/components/comment/CommentBox.kt
+++ b/core/design-system/src/main/java/com/twix/designsystem/components/comment/CommentBox.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import com.twix.designsystem.R
 import com.twix.designsystem.components.comment.model.CommentUiModel
@@ -19,7 +18,7 @@ import com.twix.domain.model.enums.AppTextStyle
 @Composable
 fun CommentBox(
     uiModel: CommentUiModel,
-    onCommentChanged: (TextFieldValue) -> Unit,
+    onCommentChanged: (String) -> Unit,
     onFocusChanged: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -36,7 +35,7 @@ fun CommentBox(
         Spacer(modifier = Modifier.height(8.dp))
         CommentTextField(
             uiModel = uiModel,
-            onCommentChanged = onCommentChanged,
+            onCommitComment = onCommentChanged,
             onFocusChanged = onFocusChanged,
             modifier =
                 Modifier

--- a/core/design-system/src/main/java/com/twix/designsystem/components/comment/CommentTextField.kt
+++ b/core/design-system/src/main/java/com/twix/designsystem/components/comment/CommentTextField.kt
@@ -58,13 +58,18 @@ fun CommentTextField(
     val keyboardState by keyboardAsState()
 
     var internalValue by rememberSaveable(uiModel.comment.text) { mutableStateOf(uiModel.comment.text) }
+    var isInitialized by remember { mutableStateOf(false) }
 
     LaunchedEffect(keyboardState) {
-        when (keyboardState) {
-            Keyboard.Opened -> Unit
-            Keyboard.Closed -> {
-                onCommitComment(internalValue.trim())
-                focusManager.clearFocus()
+        if (!isInitialized) {
+            isInitialized = true
+        } else {
+            when (keyboardState) {
+                Keyboard.Opened -> Unit
+                Keyboard.Closed -> {
+                    onCommitComment(internalValue.trim())
+                    focusManager.clearFocus()
+                }
             }
         }
     }
@@ -74,8 +79,7 @@ fun CommentTextField(
             modifier
                 .onGloballyPositioned { coordinates ->
                     onPositioned(coordinates.boundsInRoot())
-                }
-                .noRippleClickable {
+                }.noRippleClickable {
                     focusRequester.requestFocus()
                 },
     ) {
@@ -123,7 +127,7 @@ fun CommentTextField(
         ) {
             repeat(CommentUiModel.COMMENT_COUNT) { index ->
                 val char =
-                    if (uiModel.hidePlaceholder) {
+                    if (uiModel.isFocused || internalValue.isNotEmpty()) {
                         internalValue.getOrNull(index)?.toString()
                     } else {
                         stringResource(R.string.comment_text_field_placeholder)[index].toString()
@@ -131,7 +135,7 @@ fun CommentTextField(
 
                 CommentCircle(
                     text = char,
-                    showPlaceholder = !uiModel.hidePlaceholder,
+                    showPlaceholder = !uiModel.isFocused && internalValue.isEmpty(),
                     showCursor = uiModel.isFocused && index == internalValue.length,
                     modifier =
                         Modifier.noRippleClickable {

--- a/core/design-system/src/main/java/com/twix/designsystem/components/comment/CommentTextField.kt
+++ b/core/design-system/src/main/java/com/twix/designsystem/components/comment/CommentTextField.kt
@@ -127,11 +127,10 @@ fun CommentTextField(
                 CommentCircle(
                     text = char,
                     showPlaceholder = !uiModel.hidePlaceholder,
-                    showCursor = uiModel.showCursor(index),
+                    showCursor = uiModel.isFocused && index == internalValue.length,
                     modifier =
                         Modifier.noRippleClickable {
                             focusRequester.requestFocus()
-                            //onCommentChanged(uiModel.comment.copy(selection = TextRange(uiModel.comment.text.length)))
                         },
                 )
             }

--- a/core/design-system/src/main/java/com/twix/designsystem/components/comment/CommentTextField.kt
+++ b/core/design-system/src/main/java/com/twix/designsystem/components/comment/CommentTextField.kt
@@ -74,13 +74,18 @@ fun CommentTextField(
             modifier
                 .onGloballyPositioned { coordinates ->
                     onPositioned(coordinates.boundsInRoot())
-                }.noRippleClickable {
+                }
+                .noRippleClickable {
                     focusRequester.requestFocus()
                 },
     ) {
         TextField(
             value = internalValue,
-            onValueChange = { newValue -> internalValue = newValue },
+            onValueChange = { newValue ->
+                if (newValue.length <= CommentUiModel.COMMENT_COUNT) {
+                    internalValue = newValue
+                }
+            },
             enabled = enabled,
             modifier =
                 Modifier

--- a/core/design-system/src/main/java/com/twix/designsystem/components/comment/CommentTextField.kt
+++ b/core/design-system/src/main/java/com/twix/designsystem/components/comment/CommentTextField.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -23,7 +24,6 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ImeAction
@@ -55,28 +55,12 @@ fun CommentTextField(
 ) {
     val focusManager = LocalFocusManager.current
     val focusRequester = remember { FocusRequester() }
-    val keyboardController = LocalSoftwareKeyboardController.current
-    val placeholder = stringResource(R.string.comment_text_field_placeholder)
+    val keyboardState by keyboardAsState()
 
-    val keyboardVisibility by keyboardAsState()
-
-    LaunchedEffect(keyboardVisibility) {
-        when (keyboardVisibility) {
+    LaunchedEffect(keyboardState) {
+        when (keyboardState) {
             Keyboard.Opened -> Unit
-            Keyboard.Closed -> {
-                focusManager.clearFocus()
-                onFocusChanged(false)
-            }
-        }
-    }
-
-    LaunchedEffect(uiModel.isFocused) {
-        if (uiModel.isFocused) {
-            focusRequester.requestFocus()
-            awaitFrame()
-            keyboardController?.show()
-        } else {
-            keyboardController?.hide()
+            Keyboard.Closed -> focusManager.clearFocus()
         }
     }
 
@@ -85,7 +69,8 @@ fun CommentTextField(
             modifier
                 .onGloballyPositioned { coordinates ->
                     onPositioned(coordinates.boundsInRoot())
-                }.noRippleClickable {
+                }
+                .noRippleClickable {
                     focusRequester.requestFocus()
                 },
     ) {
@@ -101,6 +86,7 @@ fun CommentTextField(
                         onFocusChanged(focusState.isFocused)
                     },
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
             singleLine = true,
         )
 
@@ -132,7 +118,7 @@ fun CommentTextField(
                             .getOrNull(index)
                             ?.toString()
                     } else {
-                        placeholder.getOrNull(index)?.toString()
+                        stringResource(R.string.comment_text_field_placeholder)[index].toString()
                     }.orEmpty()
 
                 CommentCircle(

--- a/core/design-system/src/main/java/com/twix/designsystem/components/comment/CommentTextField.kt
+++ b/core/design-system/src/main/java/com/twix/designsystem/components/comment/CommentTextField.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -57,7 +56,7 @@ fun CommentTextField(
     val focusRequester = remember { FocusRequester() }
     val keyboardState by keyboardAsState()
 
-    var internalValue by rememberSaveable(uiModel.comment.text) { mutableStateOf(uiModel.comment.text) }
+    var internalValue by rememberSaveable(uiModel.comment) { mutableStateOf(uiModel.comment) }
     var isInitialized by remember { mutableStateOf(false) }
 
     LaunchedEffect(keyboardState) {
@@ -151,7 +150,7 @@ fun CommentTextField(
 @Composable
 private fun CommentTextFieldPreview() {
     TwixTheme {
-        var text by remember { mutableStateOf(TextFieldValue("")) }
+        var text by remember { mutableStateOf("") }
         var isFocused by remember { mutableStateOf(false) }
         CommentTextField(
             uiModel = CommentUiModel(text, isFocused),

--- a/core/design-system/src/main/java/com/twix/designsystem/components/comment/CommentTextField.kt
+++ b/core/design-system/src/main/java/com/twix/designsystem/components/comment/CommentTextField.kt
@@ -3,9 +3,10 @@ package com.twix.designsystem.components.comment
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -38,7 +39,6 @@ import com.twix.designsystem.theme.TwixTheme
 import com.twix.ui.extension.noRippleClickable
 import com.twix.ui.keyboard.Keyboard
 import com.twix.ui.keyboard.keyboardAsState
-import kotlinx.coroutines.android.awaitFrame
 
 val CIRCLE_PADDING_START: Dp = 50.dp
 val CIRCLE_SIZE: Dp = 64.dp
@@ -69,17 +69,17 @@ fun CommentTextField(
             modifier
                 .onGloballyPositioned { coordinates ->
                     onPositioned(coordinates.boundsInRoot())
-                }
-                .noRippleClickable {
+                }.noRippleClickable {
                     focusRequester.requestFocus()
                 },
     ) {
-        BasicTextField(
+        TextField(
             value = uiModel.comment,
             onValueChange = { newValue -> onCommentChanged(newValue) },
             enabled = enabled,
             modifier =
                 Modifier
+                    .width(0.dp)
                     .alpha(0f)
                     .focusRequester(focusRequester)
                     .onFocusChanged { focusState ->

--- a/core/design-system/src/main/java/com/twix/designsystem/components/comment/model/CommentUiModel.kt
+++ b/core/design-system/src/main/java/com/twix/designsystem/components/comment/model/CommentUiModel.kt
@@ -27,21 +27,6 @@ data class CommentUiModel(
     fun updateFocus(isFocused: Boolean) = copy(isFocused = isFocused)
 
     /**
-     * 특정 index 위치에 커서를 표시할지 여부를 반환한다.
-     *
-     * 표시 조건
-     * 1. 포커스 상태일 것
-     * 2. 현재 selection 시작 위치가 해당 index 일 것
-     * 3. 해당 위치에 문자가 없을 것 (빈 칸)
-     *
-     * @param index 확인할 문자 위치
-     */
-    fun showCursor(index: Int): Boolean {
-        val isCharEmpty = comment.text.getOrNull(index) == null
-        return isFocused && comment.selection.start == index && isCharEmpty
-    }
-
-    /**
      * 플레이스홀더 표시 여부.
      *
      * 표시 조건

--- a/core/design-system/src/main/java/com/twix/designsystem/components/comment/model/CommentUiModel.kt
+++ b/core/design-system/src/main/java/com/twix/designsystem/components/comment/model/CommentUiModel.kt
@@ -19,9 +19,9 @@ data class CommentUiModel(
                 comment.text.isNotEmpty() &&
                 hasMaxCommentLength
 
-    fun updateComment(newComment: TextFieldValue): CommentUiModel {
-        if (comment.text.length > COMMENT_COUNT) return this
-        return copy(comment = newComment)
+    fun updateComment(newComment: String): CommentUiModel {
+        if (newComment.length > COMMENT_COUNT) return this
+        return copy(comment = TextFieldValue(newComment))
     }
 
     fun updateFocus(isFocused: Boolean) = copy(isFocused = isFocused)

--- a/core/design-system/src/main/java/com/twix/designsystem/components/comment/model/CommentUiModel.kt
+++ b/core/design-system/src/main/java/com/twix/designsystem/components/comment/model/CommentUiModel.kt
@@ -26,17 +26,6 @@ data class CommentUiModel(
 
     fun updateFocus(isFocused: Boolean) = copy(isFocused = isFocused)
 
-    /**
-     * 플레이스홀더 표시 여부.
-     *
-     * 표시 조건
-     * - 포커스 중이 아니거나
-     * - 텍스트가 하나라도 존재하지 않으면
-     *
-     */
-    val hidePlaceholder: Boolean
-        get() = isFocused || comment.text.isNotEmpty()
-
     companion object {
         const val COMMENT_COUNT = 5
     }

--- a/core/design-system/src/main/java/com/twix/designsystem/components/comment/model/CommentUiModel.kt
+++ b/core/design-system/src/main/java/com/twix/designsystem/components/comment/model/CommentUiModel.kt
@@ -8,6 +8,8 @@ data class CommentUiModel(
     val comment: TextFieldValue = TextFieldValue(""),
     val isFocused: Boolean = false,
 ) {
+    constructor(value: String) : this(TextFieldValue(value))
+
     val hasMaxCommentLength: Boolean
         get() = comment.text.length == COMMENT_COUNT
 

--- a/core/design-system/src/main/java/com/twix/designsystem/components/comment/model/CommentUiModel.kt
+++ b/core/design-system/src/main/java/com/twix/designsystem/components/comment/model/CommentUiModel.kt
@@ -1,28 +1,22 @@
 package com.twix.designsystem.components.comment.model
 
 import androidx.compose.runtime.Immutable
-import androidx.compose.ui.text.input.TextFieldValue
 
 @Immutable
 data class CommentUiModel(
-    val comment: TextFieldValue = TextFieldValue(""),
+    val comment: String = "",
     val isFocused: Boolean = false,
 ) {
-    constructor(value: String) : this(TextFieldValue(value))
-
     val hasMaxCommentLength: Boolean
-        get() = comment.text.length == COMMENT_COUNT
+        get() = comment.length == COMMENT_COUNT
 
     val canUpload: Boolean
         get() =
-            comment.text.isEmpty() ||
-                comment.text.isNotEmpty() &&
+            comment.isEmpty() ||
+                comment.isNotEmpty() &&
                 hasMaxCommentLength
 
-    fun updateComment(newComment: String): CommentUiModel {
-        if (newComment.length > COMMENT_COUNT) return this
-        return copy(comment = TextFieldValue(newComment))
-    }
+    fun updateComment(newComment: String): CommentUiModel = copy(comment = newComment)
 
     fun updateFocus(isFocused: Boolean) = copy(isFocused = isFocused)
 

--- a/feature/task-certification/src/main/java/com/twix/task_certification/certification/TaskCertificationScreen.kt
+++ b/feature/task-certification/src/main/java/com/twix/task_certification/certification/TaskCertificationScreen.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -194,7 +193,7 @@ private fun TaskCertificationScreen(
     onClickGallery: () -> Unit,
     onClickRefresh: () -> Unit,
     onClickUpload: () -> Unit,
-    onCommentChanged: (TextFieldValue) -> Unit,
+    onCommentChanged: (String) -> Unit,
     onFocusChanged: (Boolean) -> Unit,
 ) {
     val focusManager = LocalFocusManager.current

--- a/feature/task-certification/src/main/java/com/twix/task_certification/certification/TaskCertificationViewModel.kt
+++ b/feature/task-certification/src/main/java/com/twix/task_certification/certification/TaskCertificationViewModel.kt
@@ -128,7 +128,7 @@ class TaskCertificationViewModel(
                     PhotologParam(
                         goalId = goalId,
                         fileName = fileName,
-                        comment = currentState.commentUiModel.comment.text,
+                        comment = currentState.commentUiModel.comment,
                         verificationDate = LocalDate.now(),
                     ),
                 )

--- a/feature/task-certification/src/main/java/com/twix/task_certification/certification/TaskCertificationViewModel.kt
+++ b/feature/task-certification/src/main/java/com/twix/task_certification/certification/TaskCertificationViewModel.kt
@@ -36,8 +36,8 @@ class TaskCertificationViewModel(
             is TaskCertificationIntent.ToggleLens -> reduceLens()
             is TaskCertificationIntent.ToggleTorch -> reduceTorch()
             is TaskCertificationIntent.RetakePicture -> setupRetake()
-            is TaskCertificationIntent.UpdateComment -> updateComment(intent)
-            is TaskCertificationIntent.CommentFocusChanged -> updateCommentFocus(intent.isFocused)
+            is TaskCertificationIntent.UpdateComment -> reduceComment(intent.value)
+            is TaskCertificationIntent.CommentFocusChanged -> reduceCommentFocus(intent.isFocused)
             is TaskCertificationIntent.TryUpload -> checkUpload()
             is TaskCertificationIntent.Upload -> upload(intent.image)
         }
@@ -58,7 +58,7 @@ class TaskCertificationViewModel(
     private fun reducePicture(uri: Uri) {
         reduce { updatePicture(uri) }
         if (uiState.value.hasMaxCommentLength.not()) {
-            updateCommentFocus(true)
+            reduceCommentFocus(true)
         }
     }
 
@@ -74,11 +74,11 @@ class TaskCertificationViewModel(
         reduce { removePicture() }
     }
 
-    private fun updateComment(intent: TaskCertificationIntent.UpdateComment) {
-        reduce { updateComment(intent.comment) }
+    private fun reduceComment(comment: String) {
+        reduce { updateComment(comment) }
     }
 
-    private fun updateCommentFocus(isFocused: Boolean) {
+    private fun reduceCommentFocus(isFocused: Boolean) {
         reduce { updateCommentFocus(isFocused) }
     }
 

--- a/feature/task-certification/src/main/java/com/twix/task_certification/certification/model/TaskCertificationIntent.kt
+++ b/feature/task-certification/src/main/java/com/twix/task_certification/certification/model/TaskCertificationIntent.kt
@@ -1,7 +1,6 @@
 package com.twix.task_certification.certification.model
 
 import android.net.Uri
-import androidx.compose.ui.text.input.TextFieldValue
 import com.twix.ui.base.Intent
 
 sealed interface TaskCertificationIntent : Intent {
@@ -20,7 +19,7 @@ sealed interface TaskCertificationIntent : Intent {
     data object RetakePicture : TaskCertificationIntent
 
     data class UpdateComment(
-        val comment: TextFieldValue,
+        val value: String,
     ) : TaskCertificationIntent
 
     data class CommentFocusChanged(

--- a/feature/task-certification/src/main/java/com/twix/task_certification/certification/model/TaskCertificationUiState.kt
+++ b/feature/task-certification/src/main/java/com/twix/task_certification/certification/model/TaskCertificationUiState.kt
@@ -3,7 +3,6 @@ package com.twix.task_certification.certification.model
 import android.net.Uri
 import androidx.camera.core.CameraSelector
 import androidx.compose.runtime.Immutable
-import androidx.compose.ui.text.input.TextFieldValue
 import com.twix.designsystem.components.comment.model.CommentUiModel
 import com.twix.ui.base.State
 
@@ -48,7 +47,7 @@ data class TaskCertificationUiState(
 
     fun removePicture(): TaskCertificationUiState = copy(capture = CaptureStatus.NotCaptured)
 
-    fun updateComment(comment: TextFieldValue) = copy(commentUiModel = commentUiModel.updateComment(comment))
+    fun updateComment(comment: String) = copy(commentUiModel = commentUiModel.updateComment(comment))
 
     fun updateCommentFocus(isFocused: Boolean) = copy(commentUiModel = commentUiModel.updateFocus(isFocused))
 

--- a/feature/task-certification/src/main/java/com/twix/task_certification/detail/component/CertificatedCard.kt
+++ b/feature/task-certification/src/main/java/com/twix/task_certification/detail/component/CertificatedCard.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
@@ -35,7 +34,7 @@ internal fun CertificatedCard(uiModel: PhotologDetailUiModel) {
         )
         if (uiModel.comment?.isNotEmpty() == true) {
             CommentTextField(
-                uiModel = CommentUiModel(TextFieldValue(uiModel.comment)),
+                uiModel = CommentUiModel(uiModel.comment),
                 enabled = false,
                 modifier =
                     Modifier


### PR DESCRIPTION
## 이슈 번호
<!-- 작업이 완료된 이슈의 번호를 기록해주세요. -->
#52 

## 리뷰/머지 희망 기한 (선택)
<!-- 해당 PR이 언제까지 리뷰되길 바라는지 작성해주세요 -->


## 작업내용
<!-- 작업한 내용을 설명해주세요. 왜 수정했는지 ? 무엇을 구현했는지 등등 -->
- 지난 [PR](https://github.com/YAPP-Github/Twix-Android/pull/49)에서 리뷰해준 내용들 적용
- 코멘트 5글자 입력 제한 추가
- 스페이스바 연타시 커서가 뒤로 넘어가는 문제 수정

## 결과물
<!-- 구현한 것을 스크린샷, 영상 또는 GIF 형태로 올려주세요. -->

<!---
| Before | After |
|:--:|:--:|
| (이미지) | (이미지) |
!--->


## 리뷰어에게 추가로 요구하는 사항 (선택)
<!-- 이 부분을 자세히 봐야한다 또는 함수 로직에 확신이 없는데 더 좋은 방법이 있을까요? 등등 -->
> 텍스트필드에 입력되는 변수를 뷰모델이 관리하는 전체 상태 변수에 넣으면 키보드로 값을 입력할 때마다 전체 화면이 리컴포지션이 발생해요 그래서 가급적이면 텍스트 필드 변수는 로컬 상태 변수로 처리하고 콜백으로 뷰모델에 넘기는 게 좋을 거 같은데 어떻게 생각하시나요??

이 리뷰 현수가 구현한 내용 참고해서 반영해봤어 !

대장님이랑 이야기해서 우선 코멘트 중간 수정은 당장에 안하기로 결정했구 
코멘트는 아에 입력하지 않거나 입력했을 경우 반드시 5글자인 경우에만 허용돼 :)