### PR TITLE
인증샷 상세 화면 인터렉션 수정

### DIFF
--- a/feature/task-certification/src/main/java/com/twix/task_certification/certification/TaskCertificationViewModel.kt
+++ b/feature/task-certification/src/main/java/com/twix/task_certification/certification/TaskCertificationViewModel.kt
@@ -125,7 +125,6 @@ class TaskCertificationViewModel(
     }
 
     private fun upload(image: ByteArray) {
-        reduce { copy(isLoading = true) }
         launchResult(
             onStart = { reduce { copy(isLoading = true) } },
             block = {
@@ -145,9 +144,9 @@ class TaskCertificationViewModel(
                 }
             },
             onError = {
+                reduce { copy(isLoading = false) }
                 showToast(R.string.task_certification_upload_fail, ToastType.ERROR)
             },
-            onFinally = { reduce { copy(isLoading = false) } },
         )
     }
 

--- a/feature/task-certification/src/main/java/com/twix/task_certification/detail/TaskCertificationDetail.kt
+++ b/feature/task-certification/src/main/java/com/twix/task_certification/detail/TaskCertificationDetail.kt
@@ -8,8 +8,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -125,24 +123,20 @@ fun TaskCertificationDetailScreen(
     onClickSting: () -> Unit,
     onSwipe: () -> Unit,
 ) {
-    Scaffold(
-        topBar = {
-            TaskCertificationDetailTopBar(
-                title = uiState.goalName,
-                canModify = uiState.canModify,
-                onBack = onBack,
-                onClickModify = onClickModify,
-            )
-        },
-    ) { innerPadding ->
-        Column(
-            Modifier
-                .padding(innerPadding)
-                .fillMaxSize()
-                .background(color = CommonColor.White),
-        ) {
-            Spacer(Modifier.height(103.dp))
+    Column(
+        Modifier
+            .fillMaxSize()
+            .background(color = CommonColor.White),
+    ) {
+        TaskCertificationDetailTopBar(
+            title = uiState.goalName,
+            canModify = uiState.canModify,
+            onBack = onBack,
+            onClickModify = onClickModify,
+        )
+        Spacer(Modifier.height(103.dp))
 
+        if (uiState.isLoading) {
             TaskCertificationCardContent(
                 uiState = uiState,
                 onSwipe = onSwipe,

--- a/feature/task-certification/src/main/java/com/twix/task_certification/detail/TaskCertificationDetailViewModel.kt
+++ b/feature/task-certification/src/main/java/com/twix/task_certification/detail/TaskCertificationDetailViewModel.kt
@@ -67,6 +67,7 @@ class TaskCertificationDetailViewModel(
             onError = {
                 showToast(R.string.task_certification_detail_fetch_photolog_fail, ToastType.ERROR)
             },
+            onFinally = { reduce { copy(isLoading = true) } },
         )
     }
 

--- a/feature/task-certification/src/main/java/com/twix/task_certification/detail/component/TaskCertificationCardContent.kt
+++ b/feature/task-certification/src/main/java/com/twix/task_certification/detail/component/TaskCertificationCardContent.kt
@@ -34,6 +34,7 @@ internal fun TaskCertificationCardContent(
 
         SwipeableCard(
             onSwipe = onSwipe,
+            isDisplayingMyPhoto = uiState.isDisplayedMyPhotolog,
             modifier = Modifier.fillMaxWidth(),
         ) {
             ForegroundCard(

--- a/feature/task-certification/src/main/java/com/twix/task_certification/detail/component/swipe/SwipeableCard.kt
+++ b/feature/task-certification/src/main/java/com/twix/task_certification/detail/component/swipe/SwipeableCard.kt
@@ -34,6 +34,7 @@ import kotlin.math.roundToInt
 @Composable
 fun SwipeableCard(
     onSwipe: () -> Unit,
+    isDisplayingMyPhoto: Boolean,
     modifier: Modifier = Modifier,
     spec: SwipeCardSpec = SwipeCardSpec(),
     content: @Composable () -> Unit,
@@ -45,7 +46,6 @@ fun SwipeableCard(
      * 카드 상태 값
      */
     val offsetX = remember { Animatable(0f) }
-    val offsetY = remember { Animatable(0f) }
     val opacity = remember { Animatable(1f) }
 
     /**
@@ -64,7 +64,7 @@ fun SwipeableCard(
                 .offset {
                     IntOffset(
                         offsetX.value.roundToInt(),
-                        offsetY.value.roundToInt(),
+                        0,
                     )
                 }
                 /**
@@ -73,7 +73,7 @@ fun SwipeableCard(
                 .graphicsLayer {
                     rotationZ = rotation
                     alpha = opacity.value
-                }.pointerInput(Unit) {
+                }.pointerInput(isDisplayingMyPhoto) {
                     detectDragGestures(
                         /**
                          * 드래그 중
@@ -84,7 +84,6 @@ fun SwipeableCard(
 
                             coroutineScope.launch {
                                 offsetX.snapTo(offsetX.value + dragAmount.x)
-                                offsetY.snapTo(offsetY.value + dragAmount.y)
                             }
                         },
                         /**
@@ -92,15 +91,7 @@ fun SwipeableCard(
                          */
                         onDragEnd = {
                             val thresholdPx = with(density) { spec.dismissThresholdDp.toPx() }
-
-                            val isHorizontal = abs(offsetX.value) > abs(offsetY.value)
-
-                            val shouldDismiss =
-                                if (isHorizontal) {
-                                    abs(offsetX.value) > thresholdPx
-                                } else {
-                                    abs(offsetY.value) > thresholdPx
-                                }
+                            val shouldDismiss = abs(offsetX.value) > thresholdPx
 
                             if (shouldDismiss) {
                                 coroutineScope.launch {
@@ -108,33 +99,19 @@ fun SwipeableCard(
                                      * 화면 밖으로 날리기
                                      */
                                     val targetX =
-                                        if (isHorizontal) {
-                                            if (offsetX.value > 0) {
-                                                spec.dismissDistancePx
-                                            } else {
-                                                -spec.dismissDistancePx
-                                            }
+                                        if (offsetX.value > 0) {
+                                            spec.dismissDistancePx
                                         } else {
-                                            0f
+                                            -spec.dismissDistancePx
                                         }
 
-                                    val targetY =
-                                        if (!isHorizontal) {
-                                            if (offsetY.value > 0) {
-                                                spec.dismissDistancePx
-                                            } else {
-                                                -spec.dismissDistancePx
-                                            }
-                                        } else {
-                                            0f
-                                        }
+                                    val targetY = 0f
 
                                     /**
                                      * dismiss 애니메이션 완료 대기
                                      */
                                     coroutineScope {
                                         launch { offsetX.animateTo(targetX, tween(spec.dismissDuration)) }
-                                        launch { offsetY.animateTo(targetY, tween(spec.dismissDuration)) }
                                         launch { opacity.animateTo(0f, tween(spec.dismissDuration)) }
                                     }
 
@@ -146,23 +123,19 @@ fun SwipeableCard(
                                     /**
                                      * 반대편 위치 세팅
                                      */
-                                    offsetX.snapTo(-targetX * spec.reappearOffsetRatio)
-                                    offsetY.snapTo(-targetY * spec.reappearOffsetRatio)
+                                    val reappearStartX =
+                                        if (isDisplayingMyPhoto) {
+                                            spec.dismissDistancePx * spec.reappearOffsetRatio
+                                        } else {
+                                            -spec.dismissDistancePx * spec.reappearOffsetRatio
+                                        }
+                                    offsetX.snapTo(reappearStartX)
 
                                     /**
                                      * 스프링 복귀
                                      */
                                     launch {
                                         offsetX.animateTo(
-                                            0f,
-                                            spring(
-                                                dampingRatio = spec.springDamping,
-                                                stiffness = spec.springStiffness,
-                                            ),
-                                        )
-                                    }
-                                    launch {
-                                        offsetY.animateTo(
                                             0f,
                                             spring(
                                                 dampingRatio = spec.springDamping,
@@ -178,7 +151,6 @@ fun SwipeableCard(
                                 // threshold 미만 → 제자리 복귀
                                 coroutineScope.launch {
                                     launch { offsetX.animateTo(0f, spring()) }
-                                    launch { offsetY.animateTo(0f, spring()) }
                                 }
                             }
                         },

--- a/feature/task-certification/src/main/java/com/twix/task_certification/detail/contract/TaskCertificationDetailUiState.kt
+++ b/feature/task-certification/src/main/java/com/twix/task_certification/detail/contract/TaskCertificationDetailUiState.kt
@@ -21,6 +21,10 @@ data class TaskCertificationDetailUiState(
     val icon: GoalIconType = GoalIconType.DEFAULT,
     val myPhotolog: PhotologDetail? = null,
     val partnerPhotolog: PhotologDetail? = null,
+    /**
+     * 초기값으로 인해 찌르기/업로드 버튼이 렌더링 되는 것을 막기 위한 변수
+     * */
+    val isLoading: Boolean = false,
 ) : State {
     val isDisplayedGoalCertificated: Boolean
         get() =

--- a/feature/task-certification/src/main/java/com/twix/task_certification/detail/contract/TaskCertificationDetailUiState.kt
+++ b/feature/task-certification/src/main/java/com/twix/task_certification/detail/contract/TaskCertificationDetailUiState.kt
@@ -78,7 +78,7 @@ data class TaskCertificationDetailUiState(
         get() =
             currentShow == BetweenUs.PARTNER && isDisplayedGoalCertificated
 
-    fun toSerializer() =
+    fun toNavArgs() =
         EditorNavArgs(
             goalId = goalId,
             nickname = myNickname,

--- a/feature/task-certification/src/main/java/com/twix/task_certification/navigation/TaskCertificationGraph.kt
+++ b/feature/task-certification/src/main/java/com/twix/task_certification/navigation/TaskCertificationGraph.kt
@@ -53,7 +53,7 @@ object TaskCertificationGraph : NavGraphContributor {
                         navController.navigate(destination)
                     },
                     navigateToEditor = { uiState ->
-                        val serializer = uiState.toSerializer()
+                        val serializer = uiState.toNavArgs()
                         navController.navigate(
                             NavRoutes.TaskCertificationEditorRoute.createRoute(
                                 serializer,


### PR DESCRIPTION
## 이슈 번호
<!-- 작업이 완료된 이슈의 번호를 기록해주세요. -->
#104

## 작업내용
<!-- 작업한 내용을 설명해주세요. 왜 수정했는지 ? 무엇을 구현했는지 등등 -->
- 인증샷 상세 화면 카드 스와이프 인터렉션 수정
- 인증 상세 화면 초기값에 대한 UI가 렌더링 되는 문제 수정

## 결과물
<!-- 구현한 것을 스크린샷, 영상 또는 GIF 형태로 올려주세요. -->

| Before | After |
|:--:|:--:|
| <img src="https://github.com/user-attachments/assets/c6475f5c-dee5-46fa-84b5-55448be20cd4" width="260"/>| <img src="https://github.com/user-attachments/assets/6192e748-9c67-40ae-bd1d-f12e420bc317" width="260"/> |

## 리뷰어에게 추가로 요구하는 사항 (선택)
<!-- 이 부분을 자세히 봐야한다 또는 함수 로직에 확신이 없는데 더 좋은 방법이 있을까요? 등등 -->
현재 변경된 인터렉션을 구현하긴 했는데 가은이가 이야기하는거 보니까 아직 이것도 픽스는 아닌듯 ㅇㅅㅇ,,,
우선 데모데이를 위해 IOS랑 동일하게만 구현했어

- 내 사진에서 좌, 우로 스와이프 여부에 관계 없이 상대 사진은 오른쪽에서 스와이프
- 상대 사진에서 좌우 스와이프 여부에 관계 없이 내 사진은 왼쪽에서 스와이프

2. Before영상에 보이는 것 처럼 UiState의 초기 상태에 대한 UI가 렌더링 되는 현상이 발생해서 임시로 isLoading 프로퍼티를 통해
조건부로 UI를 렌더링하게 만들었어 


Topbar 까지 조건부 렌더링에 추가하면 아에 빈 화면이 렌더링 되서 뒤로가기도 못하는지라 Topbar는 제외했어
임시로 구현한거라 추후에 로딩 프로그래스바 디자인 나오면 적용하면 될듯 !