### PR TITLE
로그인 & 통계 상세 화면 일러스트 변경

### DIFF
--- a/core/design-system/src/main/res/drawable/ic_hug.xml
+++ b/core/design-system/src/main/res/drawable/ic_hug.xml
@@ -4,120 +4,164 @@
     android:viewportWidth="86"
     android:viewportHeight="64">
   <path
-      android:pathData="M23.926,17.978C23.926,17.978 27.184,11.743 24.042,9.425C23.34,8.91 22.365,8.822 21.685,9.391C21.283,9.724 20.24,11.22 21.658,12.191"
+      android:pathData="M23.918,17.978C23.918,17.978 27.176,11.743 24.035,9.425C23.333,8.91 22.358,8.822 21.677,9.391C21.275,9.724 20.232,11.22 21.65,12.191"
       android:strokeLineJoin="round"
       android:strokeWidth="1.2"
       android:fillColor="#00000000"
       android:strokeColor="#171717"
       android:strokeLineCap="round"/>
   <path
-      android:pathData="M49.498,35.725C49.138,47.803 38.583,57.383 25.927,57.123C13.276,56.864 3.316,46.866 3.676,34.788C4.043,22.71 14.592,13.13 27.248,13.39C39.904,13.649 49.865,23.647 49.504,35.725L49.498,35.725Z"
+      android:pathData="M49.491,35.725C49.13,47.803 38.575,57.383 25.919,57.123C13.269,56.864 3.308,46.866 3.668,34.788C4.035,22.71 14.584,13.13 27.24,13.39C39.896,13.649 49.857,23.647 49.497,35.725L49.491,35.725Z"
       android:strokeLineJoin="round"
       android:strokeWidth="1.2"
       android:fillColor="#ffffff"
       android:strokeColor="#171717"
       android:strokeLineCap="round"/>
   <path
-      android:pathData="M41.49,30.346C41.65,28.534 40.163,26.924 38.17,26.75C36.177,26.576 34.432,27.905 34.273,29.718C34.114,31.531 35.6,33.141 37.593,33.314C39.586,33.488 41.331,32.159 41.49,30.346Z"
-      android:fillColor="#FFD5DE"/>
+      android:pathData="M43.036,31.865C43.235,29.792 41.563,27.934 39.301,27.715C37.039,27.497 35.044,29 34.845,31.074C34.646,33.147 36.318,35.005 38.58,35.224C40.842,35.442 42.837,33.938 43.036,31.865Z"
+      android:fillColor="#FDE0DF"/>
   <path
-      android:pathData="M21.775,33.16C24.262,33.032 26.203,31.454 26.109,29.637C26.015,27.82 23.922,26.451 21.434,26.58C18.947,26.708 17.006,28.286 17.1,30.103C17.194,31.92 19.287,33.289 21.775,33.16Z"
-      android:fillColor="#FFD5DE"/>
+      android:pathData="M16.676,34.327C19.068,34.223 20.929,32.317 20.834,30.069C20.738,27.822 18.722,26.084 16.33,26.187C13.939,26.291 12.078,28.197 12.173,30.445C12.269,32.693 14.285,34.431 16.676,34.327Z"
+      android:fillColor="#FDE0DF"/>
   <path
-      android:pathData="M20.683,23.741L24.814,26.069L19.822,26.547"
+      android:pathData="M18.032,24.287L22.084,26.636L17.158,27.068"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.11797"
+      android:fillColor="#00000000"
+      android:strokeColor="#171717"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M39.142,24.342L35.068,26.534L39.525,27.797"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.11797"
+      android:fillColor="#00000000"
+      android:strokeColor="#171717"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M22.913,30.888C22.913,30.888 21.476,31.74 22.032,32.898C22.681,34.252 26.19,34.086 28.042,33.007C28.042,33.007 31.98,35.082 34.26,33.01C34.26,33.01 35.431,32.002 34.328,31.06"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.11751"
+      android:fillColor="#00000000"
+      android:strokeColor="#171717"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M22.571,22.703C22.4,22.487 22.273,22.279 22.138,22.125C21.957,21.917 21.795,21.763 21.647,21.614C21.48,21.444 21.325,21.286 21.154,21.11C21.009,20.961 20.827,20.83 20.652,20.621C20.517,20.464 20.385,20.263 20.219,20.043"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.11751"
+      android:fillColor="#00000000"
+      android:strokeColor="#171717"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M37.081,19.983C36.885,20.209 36.684,20.371 36.528,20.534C36.321,20.751 36.15,20.932 35.98,21.087C35.778,21.269 35.59,21.423 35.39,21.598C35.22,21.753 35.073,21.955 34.862,22.169C34.702,22.329 34.509,22.497 34.309,22.723"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.11751"
+      android:fillColor="#00000000"
+      android:strokeColor="#171717"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M62.012,19.56C62.012,19.56 59.292,12.914 63.247,11.083C64.133,10.677 65.259,10.734 65.942,11.392C66.351,11.783 67.304,13.414 65.526,14.166"
       android:strokeLineJoin="round"
       android:strokeWidth="1.2"
       android:fillColor="#00000000"
       android:strokeColor="#171717"
       android:strokeLineCap="round"/>
   <path
-      android:pathData="M39.501,24.288L36.086,26.15L39.849,27.172"
-      android:strokeLineJoin="round"
-      android:strokeWidth="1.2"
-      android:fillColor="#00000000"
-      android:strokeColor="#171717"
-      android:strokeLineCap="round"/>
-  <path
-      android:pathData="M37.531,31.738C33.606,34.773 28.396,34.759 24.059,31.825"
-      android:strokeLineJoin="round"
-      android:strokeWidth="1.2"
-      android:fillColor="#00000000"
-      android:strokeColor="#171717"
-      android:strokeLineCap="round"/>
-  <path
-      android:pathData="M62.02,19.56C62.02,19.56 59.299,12.914 63.254,11.083C64.141,10.677 65.267,10.734 65.95,11.392C66.358,11.783 67.312,13.414 65.534,14.166"
-      android:strokeLineJoin="round"
-      android:strokeWidth="1.2"
-      android:fillColor="#00000000"
-      android:strokeColor="#171717"
-      android:strokeLineCap="round"/>
-  <path
-      android:pathData="M39.509,34.853C38.17,46.583 46.753,57.277 58.688,58.739C70.623,60.202 81.38,51.882 82.725,40.158C84.064,28.428 75.48,17.734 63.546,16.272C51.611,14.809 40.854,23.129 39.509,34.853Z"
+      android:pathData="M39.501,34.857C38.162,46.587 46.746,57.28 58.68,58.743C70.615,60.206 81.372,51.886 82.717,40.162C84.056,28.431 75.473,17.738 63.538,16.276C51.603,14.813 40.847,23.133 39.501,34.857Z"
       android:strokeLineJoin="round"
       android:strokeWidth="1.2"
       android:fillColor="#ffffff"
       android:strokeColor="#171717"
       android:strokeLineCap="round"/>
   <path
-      android:pathData="M50.867,30.564C50.984,28.748 49.433,27.171 47.404,27.042C45.374,26.912 43.634,28.279 43.517,30.095C43.4,31.911 44.95,33.488 46.979,33.617C49.009,33.747 50.749,32.38 50.867,30.564Z"
-      android:fillColor="#FFD5DE"/>
+      android:pathData="M49.833,29.949C50.066,28.005 48.667,26.238 46.707,26.002C44.747,25.766 42.969,27.15 42.736,29.094C42.502,31.038 43.901,32.805 45.861,33.041C47.821,33.277 49.599,31.893 49.833,29.949Z"
+      android:fillColor="#FDE0DF"/>
   <path
-      android:pathData="M68.137,33.378C68.482,31.591 66.744,29.756 64.256,29.279C61.767,28.802 59.47,29.864 59.125,31.651C58.78,33.438 60.517,35.273 63.006,35.75C65.494,36.227 67.791,35.165 68.137,33.378Z"
-      android:fillColor="#FFD5DE"/>
+      android:pathData="M68.709,36.657C69.242,34.526 67.865,32.344 65.634,31.783C63.402,31.221 61.161,32.493 60.629,34.623C60.096,36.754 61.473,38.936 63.704,39.497C65.936,40.059 68.176,38.787 68.709,36.657Z"
+      android:fillColor="#FDE0DF"/>
   <path
-      android:pathData="M47.313,32.063C50.824,35.632 56.08,36.365 60.866,34.084"
+      android:pathData="M53.395,24.752C53.292,24.497 53.228,24.261 53.143,24.075C53.028,23.824 52.916,23.631 52.816,23.446C52.704,23.236 52.6,23.041 52.486,22.823C52.389,22.639 52.252,22.462 52.142,22.212C52.057,22.023 51.987,21.793 51.891,21.535"
       android:strokeLineJoin="round"
-      android:strokeWidth="1.2"
+      android:strokeWidth="1.11751"
       android:fillColor="#00000000"
       android:strokeColor="#171717"
       android:strokeLineCap="round"/>
   <path
-      android:pathData="M46.086,25.348C47.139,27.299 48.871,27.545 50.556,26.048"
+      android:pathData="M65.887,25.687C65.635,25.847 65.397,25.946 65.201,26.058C64.941,26.208 64.726,26.334 64.519,26.434C64.273,26.552 64.049,26.646 63.809,26.758C63.601,26.858 63.403,27.01 63.14,27.156C62.942,27.264 62.709,27.37 62.454,27.531"
       android:strokeLineJoin="round"
-      android:strokeWidth="1.2"
+      android:strokeWidth="1.11751"
       android:fillColor="#00000000"
       android:strokeColor="#171717"
       android:strokeLineCap="round"/>
   <path
-      android:pathData="M60.43,27.641C61.483,29.592 63.215,29.838 64.9,28.341"
+      android:pathData="M49.605,31.683C49.605,31.683 47.971,32.029 48.127,33.305C48.308,34.794 51.685,35.762 53.785,35.333C53.785,35.333 56.851,38.561 59.674,37.328C59.674,37.328 61.106,36.748 60.364,35.503"
       android:strokeLineJoin="round"
-      android:strokeWidth="1.2"
+      android:strokeWidth="1.11751"
       android:fillColor="#00000000"
       android:strokeColor="#171717"
       android:strokeLineCap="round"/>
-  <group>
-    <clip-path
-        android:pathData="M40.773,2.32h10.706v10.622h-10.706z"/>
-    <path
-        android:pathData="M43.633,4.471C43.633,4.097 43.914,3.785 44.278,3.75L50.702,3.136C51.093,3.1 51.444,3.389 51.479,3.79C51.479,3.812 51.479,3.834 51.479,3.857L51.479,5.432C51.479,5.805 51.202,6.112 50.838,6.152L44.414,6.798C44.024,6.838 43.672,6.548 43.633,6.148C43.633,6.126 43.633,6.099 43.633,6.077L43.633,4.466L43.633,4.471Z"
-        android:fillColor="#171717"
-        android:fillType="evenOdd"/>
-    <path
-        android:pathData="M49.338,12.222C50.521,12.222 51.481,11.413 51.481,10.416C51.481,9.418 50.521,8.609 49.338,8.609C48.155,8.609 47.195,9.418 47.195,10.416C47.195,11.413 48.155,12.222 49.338,12.222Z"
-        android:fillColor="#171717"/>
-    <path
-        android:pathData="M42.916,12.941C44.099,12.941 45.059,12.132 45.059,11.135C45.059,10.137 44.099,9.328 42.916,9.328C41.733,9.328 40.773,10.137 40.773,11.135C40.773,12.132 41.733,12.941 42.916,12.941Z"
-        android:fillColor="#171717"/>
-    <path
-        android:pathData="M50.056,4.813L51.484,4.813L51.484,10.409L50.056,10.409L50.056,4.813ZM43.633,5.538L45.06,5.538L45.06,11.134L43.633,11.134L43.633,5.538Z"
-        android:fillColor="#171717"
-        android:fillType="evenOdd"/>
-  </group>
   <path
-      android:pathData="M26.351,51.52C26.351,51.52 29.892,57.12 35.852,56.78C43.275,56.359 44.171,45.133 32.433,42.597"
+      android:pathData="M48.877,24.724C49.13,24.938 49.112,24.966 49.365,25.177C49.618,25.388 49.628,25.38 49.881,25.594C50.133,25.808 50.14,25.797 50.386,26.025C50.607,26.228 50.627,26.207 50.838,26.424C51.049,26.64 51.035,26.656 51.247,26.873C51.458,27.09 51.533,27.026 51.681,27.299C51.491,27.304 51.276,27.347 51.057,27.362C50.863,27.375 50.66,27.393 50.443,27.414C50.249,27.433 50.042,27.435 49.828,27.454C49.631,27.473 49.425,27.478 49.214,27.494C49.014,27.509 48.808,27.511 48.601,27.522C48.393,27.533 48.196,27.57 47.986,27.577"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.11751"
+      android:fillColor="#00000000"
+      android:strokeColor="#171717"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M66.756,33.307C66.522,33.17 66.322,33.006 66.103,32.871C65.883,32.736 65.642,32.6 65.427,32.463C65.199,32.317 64.981,32.169 64.77,32.032C64.542,31.883 64.289,31.778 64.081,31.641C63.849,31.491 63.645,31.33 63.436,31.196C63.197,31.046 62.967,30.89 62.756,30.772C63.094,30.626 63.133,30.705 63.512,30.648C63.891,30.591 63.888,30.59 64.266,30.536C64.645,30.483 64.645,30.483 65.026,30.442C65.446,30.397 65.449,30.426 65.871,30.398C66.293,30.37 66.295,30.386 66.72,30.358C67.146,30.331 67.139,30.304 67.561,30.276"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.11751"
+      android:fillColor="#00000000"
+      android:strokeColor="#171717"
+      android:strokeLineCap="round"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M45.117,11.124L45.117,3.616C45.117,3.616 47.844,3.886 51.353,2.152L51.353,9.66"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#171717"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M43.001,13.111C44.172,13.111 45.124,12.332 45.124,11.368C45.124,10.404 44.172,9.625 43.001,9.625C41.83,9.625 40.883,10.404 40.883,11.368C40.883,12.332 41.834,13.111 43.001,13.111Z"
+      android:fillColor="#BEF0A3"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M43.001,13.111C44.172,13.111 45.124,12.332 45.124,11.368C45.124,10.404 44.172,9.625 43.001,9.625C41.83,9.625 40.883,10.404 40.883,11.368C40.883,12.332 41.834,13.111 43.001,13.111Z"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#171717"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M49.243,11.709C50.415,11.709 51.362,10.929 51.362,9.966C51.362,9.002 50.415,8.223 49.243,8.223C48.072,8.223 47.125,9.002 47.125,9.966C47.125,10.929 48.072,11.709 49.243,11.709Z"
+      android:fillColor="#BEF0A3"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M49.243,11.709C50.415,11.709 51.362,10.929 51.362,9.966C51.362,9.002 50.415,8.223 49.243,8.223C48.072,8.223 47.125,9.002 47.125,9.966C47.125,10.929 48.072,11.709 49.243,11.709Z"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#171717"
+      android:strokeLineCap="round"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M45.195,6.031C45.195,6.031 48.558,6.166 51.321,4.766"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#171717"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M26.344,51.52C26.344,51.52 29.884,57.12 35.844,56.78C43.267,56.359 44.164,45.133 32.425,42.597"
       android:fillColor="#ffffff"/>
   <path
-      android:pathData="M26.351,51.52C26.351,51.52 29.892,57.12 35.852,56.78C43.275,56.359 44.171,45.133 32.433,42.597"
+      android:pathData="M26.344,51.52C26.344,51.52 29.884,57.12 35.844,56.78C43.267,56.359 44.164,45.133 32.425,42.597"
       android:strokeLineJoin="round"
       android:strokeWidth="1.2"
       android:fillColor="#00000000"
       android:strokeColor="#171717"
       android:strokeLineCap="round"/>
   <path
-      android:pathData="M49.359,39.849C49.359,39.849 44.117,36.281 39.187,39.108C33.046,42.627 36.761,53.161 47.749,50.492"
+      android:pathData="M49.352,39.849C49.352,39.849 44.109,36.281 39.179,39.108C33.038,42.627 36.753,53.161 47.741,50.492"
       android:fillColor="#ffffff"/>
   <path
-      android:pathData="M49.359,39.849C49.359,39.849 44.117,36.281 39.187,39.108C33.046,42.627 36.761,53.161 47.749,50.492"
+      android:pathData="M49.352,39.849C49.352,39.849 44.109,36.281 39.179,39.108C33.038,42.627 36.753,53.161 47.741,50.492"
       android:strokeLineJoin="round"
       android:strokeWidth="1.2"
       android:fillColor="#00000000"

--- a/core/design-system/src/main/res/drawable/ic_singing.xml
+++ b/core/design-system/src/main/res/drawable/ic_singing.xml
@@ -1,0 +1,326 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="390dp"
+    android:height="420dp"
+    android:viewportWidth="390"
+    android:viewportHeight="420">
+  <group>
+    <clip-path
+        android:pathData="M0,0h390v420h-390z"/>
+    <path
+        android:pathData="M-84.89,5.99C-32.08,-6.84 59.37,11.78 130.82,143.21C257.43,376.14 396.78,264.14 434.31,230.41"
+        android:strokeWidth="1.4"
+        android:fillColor="#00000000"
+        android:strokeColor="#ECECEC"/>
+    <path
+        android:pathData="M-98.36,-3C-50.21,-13.54 40.5,-12.1 126.09,114.01C275.25,333.79 401.24,204.41 437.14,169.03"
+        android:strokeWidth="1.4"
+        android:fillColor="#00000000"
+        android:strokeColor="#ECECEC"/>
+    <path
+        android:pathData="M-86.72,15.74C-25.64,-0.34 66.07,29.7 131.22,167.13C241.76,400.32 420.43,306.39 434.98,270.79"
+        android:strokeWidth="1.4"
+        android:fillColor="#00000000"
+        android:strokeColor="#ECECEC"/>
+    <path
+        android:pathData="M-83.05,23.32C-21.33,9.53 69,42.96 128.15,182.72C228.53,419.87 412.72,361.53 428.8,326.5"
+        android:strokeWidth="1.4"
+        android:fillColor="#00000000"
+        android:strokeColor="#ECECEC"/>
+    <path
+        android:pathData="M-72.83,29.72C-11.11,15.93 79.31,67.19 128.74,218.54C208.65,463.21 415.69,405.45 431.76,370.42"
+        android:strokeWidth="1.4"
+        android:fillColor="#00000000"
+        android:strokeColor="#ECECEC"/>
+    <path
+        android:pathData="M41.12,25.34L26.65,58.09"
+        android:strokeWidth="1.4"
+        android:fillColor="#00000000"
+        android:strokeColor="#ECECEC"/>
+    <path
+        android:pathData="M106.64,87.28L82.66,119.18"
+        android:strokeWidth="1.4"
+        android:fillColor="#00000000"
+        android:strokeColor="#ECECEC"/>
+    <path
+        android:pathData="M296.7,241.17L236.85,372.67"
+        android:strokeWidth="1.4"
+        android:fillColor="#00000000"
+        android:strokeColor="#ECECEC"/>
+    <path
+        android:pathData="M198.73,117.92V100.88C198.73,100.88 207.3,101.08 206.7,114.29"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#171717"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M194.14,122.45C196.69,122.45 198.75,120.68 198.75,118.5C198.75,116.31 196.69,114.54 194.14,114.54C191.59,114.54 189.53,116.31 189.53,118.5C189.53,120.68 191.59,122.45 194.14,122.45Z"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#91E2F4"
+        android:strokeColor="#171717"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M164.46,76.37V59.32C164.46,59.32 170.39,59.93 178.02,56V73.05"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#171717"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M159.86,80.88C162.41,80.88 164.48,79.11 164.48,76.93C164.48,74.75 162.41,72.98 159.86,72.98C157.31,72.98 155.25,74.75 155.25,76.93C155.25,79.11 157.32,80.88 159.86,80.88Z"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#BEF0A3"
+        android:strokeColor="#171717"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M173.43,77.69C175.98,77.69 178.04,75.92 178.04,73.74C178.04,71.56 175.98,69.79 173.43,69.79C170.88,69.79 168.82,71.56 168.82,73.74C168.82,75.92 170.88,77.69 173.43,77.69Z"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#BEF0A3"
+        android:strokeColor="#171717"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M164.62,64.8C164.62,64.8 171.94,65.11 177.94,61.93"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#171717"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M256.52,97.04V79.99C256.52,79.99 262.46,80.61 270.1,76.67V93.72"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#171717"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M251.94,101.55C254.49,101.55 256.55,99.78 256.55,97.6C256.55,95.42 254.49,93.65 251.94,93.65C249.39,93.65 247.33,95.42 247.33,97.6C247.33,99.78 249.39,101.55 251.94,101.55Z"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#FFEB78"
+        android:strokeColor="#171717"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M265.5,98.36C268.05,98.36 270.11,96.59 270.11,94.41C270.11,92.23 268.05,90.46 265.5,90.46C262.95,90.46 260.89,92.23 260.89,94.41C260.89,96.59 262.95,98.36 265.5,98.36Z"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#FFEB78"
+        android:strokeColor="#171717"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M256.69,85.46C256.69,85.46 264.01,85.77 270.01,82.59"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#171717"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M213.51,211.08C186.36,208.85 183.54,180.8 198.36,174.41C211.24,168.86 219.55,181.29 219.55,181.29"
+        android:fillColor="#ffffff"/>
+    <path
+        android:pathData="M213.51,211.08C186.36,208.85 183.54,180.8 198.36,174.41C211.24,168.86 219.55,181.29 219.55,181.29"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#181818"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M325.64,200.31C325.64,200.31 336.23,191.43 347.24,199.23C359.91,208.22 351.09,231.94 324.88,227.6"
+        android:fillColor="#ffffff"/>
+    <path
+        android:pathData="M325.64,200.31C325.64,200.31 336.23,191.43 347.24,199.23C359.91,208.22 351.09,231.94 324.88,227.6"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#181818"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M291.77,146.88C291.77,146.88 293.8,137.99 300.86,137.85C307.91,137.74 308.79,146.83 303.01,146.43"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#181818"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M209.54,188.99C200.86,221.01 220.78,251.82 253.66,260.77C286.55,269.73 319.95,253.44 328.61,221.42C337.29,189.4 320.35,154.41 285.08,144.81C248.44,136.19 218.2,156.95 209.54,188.97V188.99Z"
+        android:fillColor="#ffffff"/>
+    <path
+        android:pathData="M209.54,188.99C200.86,221.01 220.78,251.82 253.66,260.77C286.55,269.73 319.95,253.44 328.61,221.42C337.29,189.4 320.35,154.41 285.08,144.81C248.44,136.19 218.2,156.95 209.54,188.97V188.99Z"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#181818"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M259.66,166.94C259.23,166.22 258.94,165.53 258.59,165.01C258.12,164.3 257.69,163.77 257.32,163.27C256.89,162.68 256.48,162.13 256.03,161.55C255.65,161.04 255.15,160.57 254.72,159.87C254.36,159.34 254.05,158.67 253.64,157.93"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#181818"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M255.52,189.01C255.52,189.01 250.75,190.81 251.81,194.58C253.04,199 263.67,200.37 269.83,198.12C269.83,198.12 280.57,206.46 288.54,201.44C288.54,201.44 292.61,199.04 289.79,195.62"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#181818"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M175.43,182.73C175.43,182.73 184.7,171.26 195.94,178.2C208.88,186.18 202.76,213.82 177.31,213.07"
+        android:fillColor="#ffffff"/>
+    <path
+        android:pathData="M175.43,182.73C175.43,182.73 184.7,171.26 195.94,178.2C208.88,186.18 202.76,213.82 177.31,213.07"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#181818"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M106.89,128.94C102,125.36 108.92,118.67 114.47,123.52C120.02,128.37 115.57,136.85 115.57,136.85"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#181818"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M113.49,136.35C76.45,141.76 52.46,176.4 57.31,210.4C62.16,244.39 96.56,264.55 131.09,259.46C165.61,254.38 189.67,225.22 184.81,191.2C179.96,157.21 151.79,132.07 113.47,136.33L113.49,136.35Z"
+        android:fillColor="#ffffff"/>
+    <path
+        android:pathData="M112.36,136.35C74.73,141.76 52.86,175.62 57.78,209.62C62.71,243.61 95.16,264.55 130.25,259.46C165.32,254.38 189.76,225.22 184.83,191.2C179.9,157.21 151.28,132.07 112.36,136.33V136.35Z"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#181818"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M61.23,206.49C33.21,206.23 28.58,180.84 43.42,173.51C56.3,167.13 65.13,177.16 65.13,177.16"
+        android:fillColor="#ffffff"/>
+    <path
+        android:pathData="M61.24,207.29C33.23,207.03 28.64,179.68 43.47,172.35C56.36,165.98 65.64,177.59 65.64,177.59"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#181818"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M42.63,167.88C42.24,166.47 26.56,162.34 28.11,143.32C29.73,123.07 55.38,119.06 62.4,138.43C69.04,156.75 54.07,166.13 54.07,166.13C54.07,166.13 60.54,179.72 50.33,180.93C40.5,182.13 42.63,167.88 42.63,167.88Z"
+        android:fillColor="#F8F4E2"/>
+    <path
+        android:pathData="M27.99,149.8C27.99,149.8 28.32,155.7 30.01,157.32C30.01,157.32 54.09,159.8 63.75,154.74C63.75,154.74 64.71,148.06 63.45,146.88C63.45,146.88 45.8,151.55 27.99,149.8Z"
+        android:fillColor="#F8A273"/>
+    <path
+        android:pathData="M27.22,142.84C27.22,142.84 26.35,148.95 28.07,150.62C28.07,150.62 54.32,152.28 64.09,147.8C64.09,147.8 64.35,141.07 63.1,139.88C63.1,139.88 45.23,144.65 27.22,142.85V142.84Z"
+        android:fillColor="#BEF0A3"/>
+    <path
+        android:pathData="M28.89,135.51C28.89,135.51 49.26,137.23 60.62,133.86C60.62,133.86 63.8,138.07 62.92,141.55C62.92,141.55 50.47,145.16 27.97,143.42L28.87,135.51H28.89Z"
+        android:fillColor="#91E2F4"/>
+    <path
+        android:pathData="M42.04,167.9C41.65,166.49 25.53,162.37 27.11,143.34C28.79,123.09 55.12,119.07 62.36,138.44C69.18,156.76 53.81,166.14 53.81,166.14C53.81,166.14 59.74,180.17 50.22,180.96C41.36,181.68 42.06,167.9 42.06,167.9H42.04Z"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#181818"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M340.93,196.01C341.32,194.7 331.51,183.34 342.08,169.21C353.32,154.15 374.71,164.28 370.45,183.13C366.42,200.95 350.47,200.56 350.47,200.56C350.47,200.56 348.65,214.58 340.32,210.26C332.29,206.1 340.95,196.01 340.95,196.01H340.93Z"
+        android:fillColor="#F8F4E2"/>
+    <path
+        android:pathData="M338.3,173.98C338.3,173.98 335.49,178.86 335.92,180.99C335.92,180.99 353.06,195.17 363.07,196.03C363.07,196.03 367.28,191.18 366.92,189.62C366.92,189.62 350.99,184.4 338.29,173.98H338.3Z"
+        android:fillColor="#F8A273"/>
+    <path
+        android:pathData="M341.26,168.97C341.26,168.97 337.49,173.27 337.92,175.38C337.92,175.38 356.96,189.63 366.67,191.02C366.67,191.02 370.31,185.96 369.96,184.41C369.96,184.41 353.99,179.27 341.26,168.97Z"
+        android:fillColor="#BEF0A3"/>
+    <path
+        android:pathData="M346.46,163.95C346.46,163.95 360.85,175.15 370.98,178.18C370.98,178.18 371.29,182.85 368.94,185C368.94,185 357.86,181.62 341.91,169.36L346.46,163.93V163.95Z"
+        android:fillColor="#91E2F4"/>
+    <path
+        android:pathData="M340.69,195.95C341.1,194.64 331.19,183.32 341.84,169.19C353.18,154.17 374.73,164.26 370.42,183.09C366.36,200.88 350.29,200.48 350.29,200.48C350.29,200.48 347.69,214.46 340.24,210.3C333.3,206.41 340.69,195.95 340.69,195.95Z"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#181818"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M111.35,194.07L110.23,197.18L111.9,206.08L116.08,201.27L122.63,200.84L127.26,199.08L133.3,202.13L132.52,192.61L125.79,192.12L120.48,191.04L115.49,194.31L111.35,194.09V194.07Z"
+        android:fillColor="#BC6159"/>
+    <path
+        android:pathData="M112.24,207.54L114.86,202.11L121.84,201.09L127.51,199.04L133.32,202.85L129.82,212.53L123.03,215.09L115.39,212.92L112.26,207.56L112.24,207.54Z"
+        android:fillColor="#F38F7F"/>
+    <path
+        android:pathData="M137.03,184.01C137.03,184.01 141.51,186.2 140.02,189.58C138.28,193.53 127.63,193.61 121.86,190.83C121.86,190.83 110.29,197.34 103.04,191.81C103.04,191.81 99.32,189.13 102.51,186.29"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#181818"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M132.75,194.03C132.75,194.03 136.66,213.68 123.7,215.03C111.8,216.26 109.37,201.03 110.49,195.09"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#181818"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M112.24,207.07C112.24,207.07 113.61,199.06 121.41,201.13C121.41,201.13 126.42,196.09 132.3,201.72"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#181818"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M143.33,152.9C142.84,153.49 142.33,153.9 141.92,154.31C141.4,154.88 140.96,155.33 140.54,155.74C140.03,156.21 139.56,156.6 139.05,157.05C138.62,157.44 138.25,157.96 137.72,158.51C137.31,158.92 136.82,159.35 136.31,159.94"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#181818"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M102.21,162.93C101.71,162.28 101.33,161.66 100.92,161.19C100.39,160.56 99.89,160.1 99.46,159.65C98.95,159.14 98.5,158.67 97.99,158.12C97.56,157.67 97.01,157.28 96.49,156.63C96.09,156.16 95.68,155.56 95.2,154.9"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#181818"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M97.19,176.84C99.41,176.84 101.2,175.04 101.2,172.83C101.2,170.62 99.41,168.82 97.19,168.82C94.98,168.82 93.19,170.62 93.19,172.83C93.19,175.04 94.98,176.84 97.19,176.84Z"
+        android:fillColor="#181818"/>
+    <path
+        android:pathData="M142.33,175.83C144.54,175.83 146.34,174.04 146.34,171.82C146.34,169.61 144.54,167.82 142.33,167.82C140.12,167.82 138.32,169.61 138.32,171.82C138.32,174.04 140.12,175.83 142.33,175.83Z"
+        android:fillColor="#181818"/>
+    <path
+        android:pathData="M159.02,200.49C166.7,200.49 172.92,194.24 172.92,186.53C172.92,178.82 166.7,172.57 159.02,172.57C151.35,172.57 145.13,178.82 145.13,186.53C145.13,194.24 151.35,200.49 159.02,200.49Z"
+        android:fillColor="#FDE0DF"/>
+    <path
+        android:pathData="M82.53,203.65C90.21,203.65 96.43,197.4 96.43,189.69C96.43,181.98 90.21,175.73 82.53,175.73C74.86,175.73 68.63,181.98 68.63,189.69C68.63,197.4 74.86,203.65 82.53,203.65Z"
+        android:fillColor="#FDE0DF"/>
+    <path
+        android:pathData="M233.62,198.53C241.33,198.53 247.58,192.28 247.58,184.57C247.58,176.86 241.33,170.61 233.62,170.61C225.91,170.61 219.66,176.86 219.66,184.57C219.66,192.28 225.91,198.53 233.62,198.53Z"
+        android:fillColor="#FDE0DF"/>
+    <path
+        android:pathData="M309.33,211.82C317.04,211.82 323.29,205.57 323.29,197.86C323.29,190.15 317.04,183.91 309.33,183.91C301.62,183.91 295.38,190.15 295.38,197.86C295.38,205.57 301.62,211.82 309.33,211.82Z"
+        android:fillColor="#FDE0DF"/>
+    <path
+        android:pathData="M296.77,167.96C296.18,168.46 295.61,168.8 295.16,169.17C294.56,169.66 294.07,170.05 293.58,170.38C292.99,170.77 292.46,171.1 291.9,171.48C291.41,171.81 290.96,172.28 290.35,172.75C289.88,173.1 289.34,173.45 288.75,173.96"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#181818"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M246.02,168.95C246.88,169.48 246.84,169.57 247.7,170.08C248.56,170.61 248.58,170.57 249.44,171.1C250.3,171.63 250.32,171.59 251.16,172.18C251.92,172.68 251.98,172.6 252.7,173.17C253.45,173.74 253.41,173.78 254.15,174.35C254.89,174.91 255.09,174.68 255.65,175.44C255.09,175.54 254.46,175.77 253.8,175.91C253.21,176.04 252.6,176.18 251.96,176.34C251.37,176.48 250.77,176.59 250.12,176.75C249.54,176.89 248.91,177 248.29,177.16C247.7,177.3 247.07,177.39 246.45,177.53C245.82,177.67 245.25,177.86 244.61,177.98"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#181818"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M301.91,187.01C301.27,186.76 300.7,186.41 300.08,186.15C299.47,185.9 298.8,185.65 298.2,185.37C297.55,185.08 296.95,184.81 296.36,184.53C295.71,184.24 295.03,184.06 294.46,183.81C293.82,183.52 293.23,183.18 292.65,182.93C291.98,182.64 291.34,182.32 290.75,182.11C291.55,181.6 291.69,181.8 292.63,181.5C293.57,181.21 293.57,181.21 294.5,180.93C295.13,180.74 295.76,180.56 296.4,180.41C297.45,180.13 297.48,180.21 298.53,179.98C299.59,179.74 299.61,179.78 300.68,179.55C301.76,179.31 301.72,179.25 302.79,179.02"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#181818"
+        android:strokeLineCap="round"/>
+  </group>
+</vector>

--- a/feature/login/src/main/java/com/twix/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/twix/login/LoginScreen.kt
@@ -113,7 +113,7 @@ private fun LoginScreen(onClickLogin: (LoginType) -> Unit) {
 
         Box(modifier = Modifier.fillMaxSize()) {
             Image(
-                imageVector = ImageVector.vectorResource(R.drawable.ic_keepi_singing),
+                imageVector = ImageVector.vectorResource(R.drawable.ic_singing),
                 contentDescription = null,
                 modifier =
                     Modifier


### PR DESCRIPTION
## 이슈 번호
<!-- 작업이 완료된 이슈의 번호를 기록해주세요. -->


## 작업내용
<!-- 작업한 내용을 설명해주세요. 왜 수정했는지 ? 무엇을 구현했는지 등등 -->
- 로그인 화면 디자인 수정
- 통계 상세 화면 일러스트 수정

## 결과물
### 로그인
| Before | After |  
|:--:|:--:|
|<img width="200" height="600" alt="스크린샷 2026-02-27 오후 3 55 55" src="https://github.com/user-attachments/assets/1d8e68f6-74bd-4ac0-b0e4-b4c94ef06047" />|<img width="200" height="600" alt="스크린샷 2026-02-27 오전 11 38 39" src="https://github.com/user-attachments/assets/bf6a35e3-5594-400a-991d-56d78857f38a" />|

### 통계 화면
| Before | After |  
|:--:|:--:|
|<img width="200" height="600" alt="image" src="https://github.com/user-attachments/assets/363e1e36-b781-4a5c-a1cc-c8ff6b8ca65a" />|<img width="200" height="600" alt="image" src="https://github.com/user-attachments/assets/7cac93df-0506-4ffd-bbe1-a3ebe69177e3" />|

## 리뷰어에게 추가로 요구하는 사항 (선택)
<!-- 이 부분을 자세히 봐야한다 또는 함수 로직에 확신이 없는데 더 좋은 방법이 있을까요? 등등 -->
