### PR TITLE
통계 화면 QA 적용

### DIFF
--- a/core/design-system/src/main/java/com/twix/designsystem/components/stats/PictureDayCell.kt
+++ b/core/design-system/src/main/java/com/twix/designsystem/components/stats/PictureDayCell.kt
@@ -104,7 +104,7 @@ fun PictureDayCell(
 
             AppText(
                 text = date.dayOfMonth.toString(),
-                style = AppTextStyle.B1,
+                style = AppTextStyle.B3,
                 color = textColor,
                 textAlign = TextAlign.Center,
             )

--- a/core/design-system/src/main/java/com/twix/designsystem/components/stats/PictureDayCell.kt
+++ b/core/design-system/src/main/java/com/twix/designsystem/components/stats/PictureDayCell.kt
@@ -68,8 +68,8 @@ fun PictureDayCell(
                     .size(36.dp)
                     .clip(cornerShape)
                     .then(
-                        if (showBackgroundCard) {
-                            Modifier.border(1.dp, borderColor, cornerShape)
+                        if (hasImage) {
+                            Modifier.border((1.2).dp, borderColor, cornerShape)
                         } else {
                             Modifier
                         },

--- a/core/design-system/src/main/java/com/twix/designsystem/components/stats/PictureDayCell.kt
+++ b/core/design-system/src/main/java/com/twix/designsystem/components/stats/PictureDayCell.kt
@@ -56,7 +56,7 @@ fun PictureDayCell(
                 modifier =
                     Modifier
                         .size(36.dp)
-                        .rotate(-16f)
+                        .rotate(16f)
                         .border(1.dp, GrayColor.C400, cornerShape)
                         .background(CommonColor.White, cornerShape),
             )

--- a/core/design-system/src/main/java/com/twix/designsystem/components/stats/StampCell.kt
+++ b/core/design-system/src/main/java/com/twix/designsystem/components/stats/StampCell.kt
@@ -31,7 +31,7 @@ fun StampCell(
             AppText(
                 text = stats.nickname,
                 style = AppTextStyle.B4,
-                color = GrayColor.C500,
+                color = GrayColor.C400,
             )
 
             Spacer(modifier = Modifier.weight(1f))
@@ -39,7 +39,7 @@ fun StampCell(
             AppText(
                 text = stringResource(R.string.stats_stamp_end_count).format(stats.completedCount),
                 style = AppTextStyle.B4,
-                color = GrayColor.C500,
+                color = GrayColor.C400,
             )
         }
 

--- a/core/design-system/src/main/java/com/twix/designsystem/components/stats/StatsCalendar.kt
+++ b/core/design-system/src/main/java/com/twix/designsystem/components/stats/StatsCalendar.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -81,16 +82,19 @@ private fun DayOfWeekHeader() {
         modifier = Modifier.fillMaxWidth(),
     ) {
         days.forEach { day ->
-            AppText(
-                text = day,
-                style = AppTextStyle.C1,
-                color = GrayColor.C300,
-                modifier =
-                    Modifier
-                        .weight(1f)
-                        .height(24.dp),
-                textAlign = TextAlign.Center,
-            )
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .height(24.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                AppText(
+                    text = day,
+                    style = AppTextStyle.C1,
+                    color = GrayColor.C300,
+                    textAlign = TextAlign.Center,
+                )
+            }
         }
     }
 }

--- a/core/design-system/src/main/java/com/twix/designsystem/components/stats/StatsCalendar.kt
+++ b/core/design-system/src/main/java/com/twix/designsystem/components/stats/StatsCalendar.kt
@@ -83,10 +83,11 @@ private fun DayOfWeekHeader() {
     ) {
         days.forEach { day ->
             Box(
-                modifier = Modifier
-                    .weight(1f)
-                    .height(24.dp),
-                contentAlignment = Alignment.Center
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .height(24.dp),
+                contentAlignment = Alignment.Center,
             ) {
                 AppText(
                     text = day,

--- a/core/design-system/src/main/java/com/twix/designsystem/components/stats/StatsCalendar.kt
+++ b/core/design-system/src/main/java/com/twix/designsystem/components/stats/StatsCalendar.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -84,7 +83,7 @@ private fun DayOfWeekHeader() {
         days.forEach { day ->
             AppText(
                 text = day,
-                style = AppTextStyle.B2,
+                style = AppTextStyle.C1,
                 color = GrayColor.C300,
                 modifier =
                     Modifier

--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -95,7 +95,7 @@
     <string name="stats_stamp_end_tab_title">종료</string>
 
     <!-- 통계 상세 화면 -->
-    <string name="stats_complete_count">%1$s %2$d/%3$d</string>
+    <string name="stats_complete_count">%1$s - %2$d/%3$d</string>
 
     <!-- 알림 화면 -->
     <string name="notification_recent_14_days">최근 14일</string>

--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -39,6 +39,10 @@
     <string name="word_friday">금</string>
     <string name="word_saturday">토</string>
 
+    <!-- 날짜 포맷 -->
+    <string name="date_year_month_day">%s년 %02d월 %02d일</string>
+    <string name="date_year_month_day_no_padding">%1$d년 %2$d월 %3$d일</string>
+
     <!-- 동작 -->
     <string name="action_edit">수정하기</string>
     <string name="action_delete">삭제하기</string>
@@ -73,7 +77,6 @@
     <string name="goal_list_title_previous">지난 우리 목표</string>
     <string name="goal_list_title_today">오늘 우리 목표</string>
     <string name="goal_list_title_next">다음 우리 목표</string>
-    <string name="date_year_month_day">%s년 %02d월 %02d일</string>
     <string name="goal_detail_empty_goal_guide">아직 목표가 없어요!</string>
 
     <!-- 설정 화면 -->

--- a/core/util/src/main/java/com/twix/util/.gitkeep
+++ b/core/util/src/main/java/com/twix/util/.gitkeep
@@ -1,1 +1,0 @@
-# This file ensures the directory is tracked by git

--- a/feature/main/src/main/java/com/twix/stats/StatsViewModel.kt
+++ b/feature/main/src/main/java/com/twix/stats/StatsViewModel.kt
@@ -44,6 +44,13 @@ class StatsViewModel(
         )
 
     init {
+        collectMonthChange()
+        fetchInProgressStats(YearMonth.from(currentState.currentDate))
+        fetchCompletedStats()
+        collectEventBus()
+    }
+
+    private fun collectMonthChange() {
         viewModelScope.launch {
             monthChangeFlow
                 .distinctUntilChanged()
@@ -52,10 +59,6 @@ class StatsViewModel(
                     fetchInProgressStats(yearMonth)
                 }
         }
-
-        fetchInProgressStats(YearMonth.from(currentState.currentDate))
-        fetchCompletedStats()
-        collectEventBus()
     }
 
     override suspend fun handleIntent(intent: StatsIntent) {

--- a/feature/main/src/main/java/com/twix/stats/component/EndStatsContent.kt
+++ b/feature/main/src/main/java/com/twix/stats/component/EndStatsContent.kt
@@ -38,7 +38,7 @@ fun EndStatsContent(
                 )
             }
         } else {
-            item { Spacer(Modifier.height(12.dp)) }
+            item { Spacer(Modifier.height(20.dp)) }
 
             items(
                 items = statsGoals,

--- a/feature/photolog/capture/src/main/java/com/twix/photolog/capture/PhotologCaptureViewModel.kt
+++ b/feature/photolog/capture/src/main/java/com/twix/photolog/capture/PhotologCaptureViewModel.kt
@@ -20,6 +20,7 @@ import com.twix.ui.image.ImageGenerator
 import com.twix.util.bus.GoalRefreshBus
 import com.twix.util.bus.PhotologRefreshBus
 import com.twix.util.bus.StatsDetailRefreshBus
+import com.twix.util.bus.StatsRefreshBus
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -32,6 +33,7 @@ class PhotologCaptureViewModel(
     private val detailRefreshBus: PhotologRefreshBus,
     private val goalRefreshBus: GoalRefreshBus,
     private val statsDetailRefreshBus: StatsDetailRefreshBus,
+    private val statsRefreshBus: StatsRefreshBus,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<PhotologCaptureUiState, PhotologCaptureIntent, PhotologCaptureSideEffect>(
         PhotologCaptureUiState(),
@@ -176,11 +178,16 @@ class PhotologCaptureViewModel(
 
     private fun handleUploadPhotologSuccess() {
         when (navArgs.from) {
-            NavRoutes.PhotologRoute.From.HOME ->
+            NavRoutes.PhotologRoute.From.HOME -> {
                 goalRefreshBus.notifyGoalListChanged()
+                statsRefreshBus.notifyChanged(StatsRefreshBus.Target.All)
+            }
 
-            NavRoutes.PhotologRoute.From.DETAIL ->
+            NavRoutes.PhotologRoute.From.DETAIL -> {
                 detailRefreshBus.notifyChanged(PhotologRefreshBus.Publisher.PHOTOLOG)
+                statsDetailRefreshBus.notifyChanged()
+                statsRefreshBus.notifyChanged(StatsRefreshBus.Target.All)
+            }
 
             NavRoutes.PhotologRoute.From.EDITOR -> Unit
         }

--- a/feature/stats/detail/src/main/java/com/twix/stats/detail/StatsDetailScreen.kt
+++ b/feature/stats/detail/src/main/java/com/twix/stats/detail/StatsDetailScreen.kt
@@ -158,6 +158,7 @@ fun StatsDetailScreen(
                 modifier =
                     Modifier
                         .fillMaxWidth()
+                        .padding(top = 32.dp)
                         .verticalScroll(scrollState),
             ) {
                 Image(
@@ -166,18 +167,17 @@ fun StatsDetailScreen(
                     modifier =
                         Modifier
                             .align(Alignment.TopStart)
-                            .padding(start = 20.dp, top = 30.dp),
+                            .padding(start = 20.dp),
                 )
 
                 Column(
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = 20.dp),
+                            .padding(horizontal = 20.dp)
+                            .padding(top = 4.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
-                    Spacer(Modifier.height(32.dp))
-
                     CalendarNavigator(
                         currentDate = uiState.detail.currentDate,
                         onPreviousMonth = onPreviousMonth,
@@ -210,7 +210,7 @@ fun StatsDetailScreen(
                     modifier =
                         Modifier
                             .align(Alignment.TopEnd)
-                            .padding(end = 27.dp, top = 30.dp),
+                            .padding(end = 27.dp),
                 )
             }
 

--- a/feature/stats/detail/src/main/java/com/twix/stats/detail/StatsDetailScreen.kt
+++ b/feature/stats/detail/src/main/java/com/twix/stats/detail/StatsDetailScreen.kt
@@ -125,6 +125,7 @@ fun StatsDetailScreen(
             modifier =
                 Modifier
                     .fillMaxSize()
+                    .verticalScroll(scrollState)
                     .background(GrayColor.C050),
         ) {
             StatsDetailTopbar(
@@ -159,7 +160,6 @@ fun StatsDetailScreen(
                     Modifier
                         .fillMaxWidth()
                         .padding(top = 32.dp)
-                        .verticalScroll(scrollState),
             ) {
                 Image(
                     imageVector = ImageVector.vectorResource(R.drawable.ic_hug),

--- a/feature/stats/detail/src/main/java/com/twix/stats/detail/StatsDetailScreen.kt
+++ b/feature/stats/detail/src/main/java/com/twix/stats/detail/StatsDetailScreen.kt
@@ -159,7 +159,7 @@ fun StatsDetailScreen(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .padding(top = 32.dp)
+                        .padding(top = 32.dp),
             ) {
                 Image(
                     imageVector = ImageVector.vectorResource(R.drawable.ic_hug),

--- a/feature/stats/detail/src/main/java/com/twix/stats/detail/component/SummaryContent.kt
+++ b/feature/stats/detail/src/main/java/com/twix/stats/detail/component/SummaryContent.kt
@@ -105,7 +105,7 @@ fun SummaryContent(
                 label = stringResource(R.string.word_start_date),
                 value =
                     stringResource(
-                        R.string.date_year_month_day,
+                        R.string.date_year_month_day_no_padding,
                         statsSummary.startDate.year,
                         statsSummary.startDate.monthValue,
                         statsSummary.startDate.dayOfMonth,
@@ -116,7 +116,7 @@ fun SummaryContent(
                 value =
                     statsSummary.endDate?.let {
                         stringResource(
-                            R.string.date_year_month_day,
+                            R.string.date_year_month_day_no_padding,
                             it.year,
                             it.monthValue,
                             it.dayOfMonth,
@@ -170,7 +170,7 @@ private fun SummaryContentPreview() {
                     partnerCompletedCount = 8,
                     totalCount = 20,
                     repeatCycle = RepeatCycle.DAILY,
-                    startDate = LocalDate.now(),
+                    startDate = LocalDate.of(2025, 11, 12),
                     endDate = LocalDate.now(),
                 ),
         )


### PR DESCRIPTION
## 이슈 번호
<!-- 작업이 완료된 이슈의 번호를 기록해주세요. -->
#126 

## 작업내용

통계 화면에서 발견된 QA 항목들을 수정

**통계 메인 화면**
- 종료 탭 ~ 리스트 사이 간격 수정 (12dp → 20dp)
- 카드 닉네임, 완료 횟수 텍스트 색상 변경 (C500 → C400)

**통계 상세페이지**
- Calendar Navigator ~ 캘린더 사이 간격 수정
- 날짜 텍스트 굵기 수정 (B1 → B3)
- 달력 요일(월~일) 텍스트를 `Box`로 감싸고 `contentAlignment = Alignment.Center` 적용하여 상단 border와의 간격 이슈 해결
- 요일 텍스트 스타일 수정 (B2 → C1)
- 사진 하나만 있을 때 이미지에 border 추가
- 달성 횟수 표기 형식 수정: `%1$s %2$d/%3$d` → `%1$s - %2$d/%3$d` (하이픈 추가)
- 사진 두 장일 때 뒤에 있는 이미지 회전 방향 수정 (`rotate(-16f)` → `rotate(16f)`)
- 하단 시작일/종료일 날짜 포맷 수정 (`03월 03일` → `3월 3일`)
`<string name="date_year_month_day_no_padding">%1$d년 %2$d월 %3$d일</string>`
- 사진 인증 시 통계 진행중 스탬프가 업데이트되지 않는 문제 수정

> ⚠️ 미완료 항목
- "진행중 탭 CalendarNavigator ~ 리스트 사이 간격 넓음 " 
- 진행중, 종료 라인 두께랑 색상 다름

## 결과물
| Before | After |
|:--:|:--:|
| <img width="280" height="600" alt="스크린샷 2026-03-09 오후 3 44 57" src="https://github.com/user-attachments/assets/6a6c057a-3f19-4d48-8868-524a62142e97" />| <img width="280" height="600" alt="스크린샷 2026-03-09 오후 3 48 34" src="https://github.com/user-attachments/assets/f893b4f3-a552-4923-95ef-f6b17d0a48e1" />
cb4-4420-83b6-023a4b0e84db" /> |

**종료 탭 간격 조정**
| Before | After |
|:--:|:--:|
| <img width="280" height="500" alt="1Before" src="https://github.com/user-attachments/assets/de2ceb30-563d-41c9-89d7-7d4adf006e5d" /> | <img width="280" height="500" alt="1After" src="https://github.com/user-attachments/assets/5c551f45-a31a-4097-90ee-b6ae85d69036" /> |

## 리뷰어에게 추가로 요구하는 사항 (선택)
미완료 항목은 노션 QA 해당 항목의 페이지에 의견 남겨놨으니 확인해줘 !