### PR TITLE
카카오 로그인 WebView 열림 문제 해결

### DIFF
--- a/feature/login/src/main/java/com/twix/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/twix/login/LoginScreen.kt
@@ -34,6 +34,8 @@ import com.twix.domain.model.enums.LoginType
 import com.twix.login.component.LoginButton
 import com.twix.login.contract.LoginIntent
 import com.twix.login.contract.LoginSideEffect
+import com.twix.login.google.GoogleLoginProvider
+import com.twix.login.kakao.KakaoLoginProvider
 import com.twix.ui.base.ObserveAsEvents
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
@@ -44,7 +46,8 @@ fun LoginRoute(
     navigateToHome: () -> Unit,
     navigateToOnBoarding: (OnboardingStatus) -> Unit,
     toastManager: ToastManager = koinInject(),
-    loginProvider: LoginProviderFactory = koinInject(),
+    kakaoLoginProvider: KakaoLoginProvider = koinInject(),
+    googleLoginProvider: GoogleLoginProvider = koinInject(),
     viewModel: LoginViewModel = koinViewModel(),
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -68,7 +71,12 @@ fun LoginRoute(
 
     LoginScreen { type ->
         coroutineScope.launch {
-            viewModel.dispatch(LoginIntent.Login(loginProvider[type].login()))
+            val result =
+                when (type) {
+                    LoginType.KAKAO -> kakaoLoginProvider.login(currentContext)
+                    LoginType.GOOGLE -> googleLoginProvider.login()
+                }
+            viewModel.dispatch(LoginIntent.Login(result))
         }
     }
 }

--- a/feature/login/src/main/java/com/twix/login/di/LoginModule.kt
+++ b/feature/login/src/main/java/com/twix/login/di/LoginModule.kt
@@ -1,8 +1,5 @@
 package com.twix.login.di
 
-import com.twix.domain.login.LoginProvider
-import com.twix.domain.model.enums.LoginType
-import com.twix.login.LoginProviderFactory
 import com.twix.login.LoginViewModel
 import com.twix.login.google.GoogleLoginProvider
 import com.twix.login.kakao.KakaoLoginProvider
@@ -18,22 +15,9 @@ val loginModule =
     module {
         single<NavGraphContributor>(named(NavRoutes.LoginGraph.route)) { LoginNavGraph }
 
-        factory<LoginProvider>(named(LoginType.GOOGLE.name)) {
-            GoogleLoginProvider(androidContext())
-        }
+        factory { GoogleLoginProvider(androidContext()) }
 
-        factory<LoginProvider>(named(LoginType.KAKAO.name)) {
-            KakaoLoginProvider(androidContext())
-        }
-
-        factory {
-            LoginProviderFactory(
-                mapOf(
-                    LoginType.GOOGLE to get<LoginProvider>(named(LoginType.GOOGLE.name)),
-                    LoginType.KAKAO to get<LoginProvider>(named(LoginType.KAKAO.name)),
-                ),
-            )
-        }
+        factory { KakaoLoginProvider() }
 
         viewModelOf(::LoginViewModel)
     }

--- a/feature/login/src/main/java/com/twix/login/kakao/KakaoLoginProvider.kt
+++ b/feature/login/src/main/java/com/twix/login/kakao/KakaoLoginProvider.kt
@@ -5,24 +5,19 @@ import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.user.UserApiClient
-import com.twix.domain.login.LoginProvider
 import com.twix.domain.login.LoginResult
 import com.twix.domain.model.enums.LoginType
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
 
-class KakaoLoginProvider(
-    private val context: Context,
-) : LoginProvider {
-    override val type: LoginType = LoginType.KAKAO
-
-    override suspend fun login(): LoginResult {
-        if (isKakaoTalkAvailable()) return loginWithTalk()
-        return loginWithAccount()
+class KakaoLoginProvider {
+    suspend fun login(context: Context): LoginResult {
+        if (isKakaoTalkAvailable(context)) return loginWithTalk(context)
+        return loginWithAccount(context)
     }
 
-    override suspend fun logout(): Result<Unit> =
+    suspend fun logout(): Result<Unit> =
         suspendCancellableCoroutine { continuation ->
             UserApiClient.instance.logout { error ->
                 if (error != null) {
@@ -33,30 +28,38 @@ class KakaoLoginProvider(
             }
         }
 
-    private fun isKakaoTalkAvailable(): Boolean = UserApiClient.instance.isKakaoTalkLoginAvailable(context)
+    private fun isKakaoTalkAvailable(context: Context): Boolean = UserApiClient.instance.isKakaoTalkLoginAvailable(context)
 
-    private suspend fun loginWithTalk(): LoginResult =
+    private suspend fun loginWithTalk(context: Context): LoginResult =
         suspendCancellableCoroutine { continuation ->
             UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
                 when {
-                    token != null -> continuation.resume(success(token))
+                    token != null -> {
+                        continuation.resume(success(token))
+                    }
                     error is ClientError &&
                         error.reason == ClientErrorCause.Cancelled -> {
                         continuation.resume(LoginResult.Cancel)
                     }
 
-                    else -> resumeWithAccountLogin(continuation)
+                    else -> {
+                        resumeWithAccountLogin(context, continuation)
+                    }
                 }
             }
         }
 
-    private suspend fun loginWithAccount(): LoginResult =
+    private suspend fun loginWithAccount(context: Context): LoginResult =
         suspendCancellableCoroutine { continuation ->
             UserApiClient.instance.loginWithKakaoAccount(context) { token, error ->
                 when {
-                    token != null -> continuation.resume(success(token))
-                    error != null -> continuation.resume(LoginResult.Failure(error))
-                    else ->
+                    token != null -> {
+                        continuation.resume(success(token))
+                    }
+                    error != null -> {
+                        continuation.resume(LoginResult.Failure(error))
+                    }
+                    else -> {
                         continuation.resume(
                             LoginResult.Failure(
                                 IllegalStateException(
@@ -64,6 +67,7 @@ class KakaoLoginProvider(
                                 ),
                             ),
                         )
+                    }
                 }
             }
         }
@@ -76,13 +80,22 @@ class KakaoLoginProvider(
         return LoginResult.Success(idToken, LoginType.KAKAO)
     }
 
-    private fun resumeWithAccountLogin(continuation: CancellableContinuation<LoginResult>) {
+    private fun resumeWithAccountLogin(
+        context: Context,
+        continuation: CancellableContinuation<LoginResult>,
+    ) {
         UserApiClient.instance.loginWithKakaoAccount(context) { token, error ->
-            if (!continuation.isActive) return@loginWithKakaoAccount
+            if (!continuation.isActive) {
+                return@loginWithKakaoAccount
+            }
 
             when {
-                token != null -> continuation.resume(success(token))
-                error != null -> continuation.resume(LoginResult.Failure(error))
+                token != null -> {
+                    continuation.resume(success(token))
+                }
+                error != null -> {
+                    continuation.resume(LoginResult.Failure(error))
+                }
             }
         }
     }

--- a/feature/login/src/main/java/com/twix/login/kakao/KakaoLoginProvider.kt
+++ b/feature/login/src/main/java/com/twix/login/kakao/KakaoLoginProvider.kt
@@ -43,7 +43,7 @@ class KakaoLoginProvider {
                     }
 
                     else -> {
-                        resumeWithAccountLogin(context, continuation)
+                        loginWithKakaoAccount(context, continuation)
                     }
                 }
             }
@@ -51,26 +51,40 @@ class KakaoLoginProvider {
 
     private suspend fun loginWithAccount(context: Context): LoginResult =
         suspendCancellableCoroutine { continuation ->
-            UserApiClient.instance.loginWithKakaoAccount(context) { token, error ->
-                when {
-                    token != null -> {
-                        continuation.resume(success(token))
-                    }
-                    error != null -> {
-                        continuation.resume(LoginResult.Failure(error))
-                    }
-                    else -> {
-                        continuation.resume(
-                            LoginResult.Failure(
-                                IllegalStateException(
-                                    UNEXPECTED_STATE_ERROR_MESSAGE,
-                                ),
-                            ),
-                        )
-                    }
-                }
+            loginWithKakaoAccount(context, continuation)
+        }
+
+    private fun loginWithKakaoAccount(
+        context: Context,
+        continuation: CancellableContinuation<LoginResult>,
+    ) {
+        UserApiClient.instance.loginWithKakaoAccount(context) { token, error ->
+            if (!continuation.isActive) return@loginWithKakaoAccount
+            handleLoginCallback(token, error, continuation)
+        }
+    }
+
+    private fun handleLoginCallback(
+        token: OAuthToken?,
+        error: Throwable?,
+        continuation: CancellableContinuation<LoginResult>,
+    ) {
+        when {
+            token != null -> {
+                continuation.resume(success(token))
+            }
+            error != null -> {
+                continuation.resume(LoginResult.Failure(error))
+            }
+            else -> {
+                continuation.resume(
+                    LoginResult.Failure(
+                        IllegalStateException(UNEXPECTED_STATE_ERROR_MESSAGE),
+                    ),
+                )
             }
         }
+    }
 
     private fun success(token: OAuthToken): LoginResult {
         val idToken =
@@ -78,26 +92,6 @@ class KakaoLoginProvider {
                 return LoginResult.Failure(IllegalStateException(ID_TOKEN_NULL_ERROR_MESSAGE))
             }
         return LoginResult.Success(idToken, LoginType.KAKAO)
-    }
-
-    private fun resumeWithAccountLogin(
-        context: Context,
-        continuation: CancellableContinuation<LoginResult>,
-    ) {
-        UserApiClient.instance.loginWithKakaoAccount(context) { token, error ->
-            if (!continuation.isActive) {
-                return@loginWithKakaoAccount
-            }
-
-            when {
-                token != null -> {
-                    continuation.resume(success(token))
-                }
-                error != null -> {
-                    continuation.resume(LoginResult.Failure(error))
-                }
-            }
-        }
     }
 
     companion object {


### PR DESCRIPTION
## 이슈 번호
Closes #150

## 작업내용

### 문제 상황
카카오 로그인 시 카카오톡 앱으로 전환되지 않고 WebView로 열리는 현상 발생

### 원인 분석
상세 로그 비교 분석을 통해 실제 원인은 **Context 타입 불일치**임을 발견:

**OLD (Application Context 사용 - 실패):**
- KakaoLoginProvider 생성자에서 Application Context를 주입받음
- `loginWithKakaoTalk()` 호출 시 "Calling startActivity() from outside of an Activity context" 에러 발생

**NEW (Activity Context 사용 - 성공):**
- Compose의 `LocalContext.current`를 통해 Activity Context를 런타임에 전달
- `loginWithKakaoTalk()` 정상 동작

### 해결 방법
1. KakaoLoginProvider에서 `LoginProvider` 인터페이스 구현 제거
2. 생성자 주입 방식에서 런타임 파라미터 전달 방식으로 변경
3. LoginScreen에서 `LocalContext.current` (Activity Context)를 전달
4. 불필요한 `LoginProviderFactory` 제거 및 각 Provider를 직접 주입하도록 DI 구조 개선

## 결과물

### 로그 비교

**OLD 방식 (Application Context - 실패):**
```
[KAKAO-OLD] isKakaoTalkAvailable() - Context: TwixApplication, 결과: true
[KAKAO-OLD] loginWithTalk() 실패 - Calling startActivity() from outside of an Activity context
```

**NEW 방식 (Activity Context - 성공):**
```
[KAKAO] isKakaoTalkAvailable() - Context: MainActivity, 결과: true
[KAKAO] loginWithTalk() 성공 - 토큰 발급됨
```

### 실행 결과
카카오 로그인 클릭 시 WebView 대신 **카카오톡 앱으로 정상 전환**

| Before | After |
|:--:|:--:|
| <img width="270" height="600" alt="before" src="https://github.com/user-attachments/assets/a292bcbd-432b-4569-81ae-f647f640eb4d" /> | <img width="270" height="600" alt="after" src="https://github.com/user-attachments/assets/af18e6ed-fc91-432e-84a0-1921787d0705" /> |


## 리뷰어에게 추가로 요구하는 사항 (선택)

### 문제 해결 상세 과정

아래 로그를 추가하여 Context 타입과 각 단계별 결과 확인:

```kotlin
// OLD 방식 (Application Context)
class KakaoLoginProvider(private val context: Context) : LoginProvider {
    private fun isKakaoTalkAvailable(): Boolean {
        val available = UserApiClient.instance.isKakaoTalkLoginAvailable(context)
        Log.d("KAKAO-OLD", "isKakaoTalkAvailable() - Context: ${context.javaClass.simpleName}, 결과: $available")
        return available
    }
    
    private suspend fun loginWithTalk(): LoginResult = suspendCancellableCoroutine { continuation ->
        UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
            when {
                token != null -> {
                    Log.d("KAKAO-OLD", "loginWithTalk() 성공 - 토큰 발급됨")
                    continuation.resume(success(token))
                }
                error != null -> {
                    Log.e("KAKAO-OLD", "loginWithTalk() 실패 - ${error.message}")
                    // ...
                }
            }
        }
    }
}
```

```kotlin
// NEW 방식 (Activity Context)
class KakaoLoginProvider {
    suspend fun login(context: Context): LoginResult {
        Log.d("KAKAO", "login() 호출 - Context: ${context.javaClass.simpleName}")
        if (isKakaoTalkAvailable(context)) return loginWithTalk(context)
        return loginWithAccount(context)
    }
    
    private fun isKakaoTalkAvailable(context: Context): Boolean {
        val available = UserApiClient.instance.isKakaoTalkLoginAvailable(context)
        Log.d("KAKAO", "isKakaoTalkAvailable() - Context: ${context.javaClass.simpleName}, 결과: $available")
        return available
    }
    
    private suspend fun loginWithTalk(context: Context): LoginResult = 
        suspendCancellableCoroutine { continuation ->
            UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
                when {
                    token != null -> {
                        Log.d("KAKAO", "loginWithTalk() 성공 - 토큰 발급됨")
                        continuation.resume(success(token))
                    }
                    error != null -> {
                        Log.e("KAKAO", "loginWithTalk() 실패 - ${error.message}")
                        // ...
                    }
                }
            }
        }
}
```

```kotlin
// LoginScreen.kt
LoginScreen { type ->
    coroutineScope.launch {
        val currentContext = LocalContext.current
        Log.d("LOGIN", "로그인 버튼 클릭 - Context: ${currentContext.javaClass.simpleName}")
        
        val result = when (type) {
            LoginType.KAKAO -> kakaoLoginProvider.login(currentContext)
            LoginType.GOOGLE -> googleLoginProvider.login()
        }
        viewModel.dispatch(LoginIntent.Login(result))
    }
}
```

#### 3. 로그 분석 결과
**OLD 방식 실행 로그:**
```
D/LOGIN: 로그인 버튼 클릭 - Context: MainActivity
D/KAKAO-OLD: isKakaoTalkAvailable() - Context: TwixApplication, 결과: true
D/KAKAO-OLD: loginWithTalk() 실패 - Calling startActivity() from outside of an Activity context
```

**NEW 방식 실행 로그:**
```
D/LOGIN: 로그인 버튼 클릭 - Context: MainActivity
D/KAKAO: login() 호출 - Context: MainActivity
D/KAKAO: isKakaoTalkAvailable() - Context: MainActivity, 결과: true
D/KAKAO: loginWithTalk() 성공 - 토큰 발급됨
```